### PR TITLE
Rejuvenate log levels

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/CoapObserveRelation.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/CoapObserveRelation.java
@@ -223,7 +223,7 @@ public class CoapObserveRelation {
 	public void reactiveCancel() {
 		Request request = this.request;
 		if (CoAP.isTcpScheme(request.getScheme())) {
-			LOGGER.info("change to cancel the observe {} proactive over TCP.", request.getTokenString());
+			LOGGER.debug("change to cancel the observe {} proactive over TCP.", request.getTokenString());
 			proactiveCancel();
 		} else {
 			// cancel old ongoing request

--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/Request.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/Request.java
@@ -257,7 +257,7 @@ public class Request extends Message {
 			String coapUri = uri;
 			if (!uri.contains("://")) {
 				coapUri = "coap://" + uri;
-				LOGGER.warn("update your code to supply an RFC 7252 compliant URI including a scheme");
+				LOGGER.debug("update your code to supply an RFC 7252 compliant URI including a scheme");
 			}
 			return setURI(new URI(coapUri));
 		} catch (URISyntaxException e) {

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/CoapEndpoint.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/CoapEndpoint.java
@@ -533,9 +533,9 @@ public class CoapEndpoint implements Endpoint {
 	@Override
 	public synchronized void stop() {
 		if (!started) {
-			LOGGER.info("{}Endpoint at {} is already stopped", tag, getUri());
+			LOGGER.severe("{}Endpoint at {} is already stopped", tag, getUri());
 		} else {
-			LOGGER.info("{}Stopping endpoint at {}", tag, getUri());
+			LOGGER.severe("{}Stopping endpoint at {}", tag, getUri());
 			started = false;
 			if (statusLogger != null) {
 				statusLogger.cancel(false);

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/CoapEndpointHealthLogger.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/CoapEndpointHealthLogger.java
@@ -64,7 +64,7 @@ public class CoapEndpointHealthLogger implements CoapEndpointHealth {
 				log.append(head).append(receivedRejects).append(eol);
 				log.append(head).append(duplicateRequests).append(eol);
 				log.append(head).append(duplicateResponses);
-				LOGGER.debug("{}", log);
+				LOGGER.trace("{}", log);
 			}
 		} catch (Throwable e) {
 			LOGGER.error("{}", tag, e);

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/EndpointManager.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/EndpointManager.java
@@ -254,7 +254,7 @@ public class EndpointManager {
 
 		@Override
 		public void deliverRequest(Exchange exchange) {
-			LOGGER.error("Default endpoint without CoapServer has received a request.");
+			LOGGER.trace("Default endpoint without CoapServer has received a request.");
 			exchange.sendReject();
 		}
 

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/InMemoryMessageExchangeStore.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/InMemoryMessageExchangeStore.java
@@ -134,7 +134,7 @@ public class InMemoryMessageExchangeStore implements MessageExchangeStore {
 		this.endpointIdentityResolver = endpointResolver;
 		this.config = config;
 		this.tag = StringUtil.normalizeLoggingTag(tag);
-		LOGGER.debug("{}using TokenProvider {}", tag, tokenProvider.getClass().getName());
+		LOGGER.trace("{}using TokenProvider {}", tag, tokenProvider.getClass().getName());
 	}
 
 	private void startStatusLogging() {

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/RandomTokenGenerator.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/RandomTokenGenerator.java
@@ -63,7 +63,7 @@ public class RandomTokenGenerator implements TokenGenerator {
 		// trigger self-seeding of the PRNG, may "take a while"
 		this.rng.nextInt(10);
 		this.tokenSize = networkConfig.getInt(Keys.TOKEN_SIZE_LIMIT, DEFAULT_TOKEN_LENGTH);
-		LOGGER.info("using tokens of {} bytes in length", this.tokenSize);
+		LOGGER.trace("using tokens of {} bytes in length", this.tokenSize);
 	}
 
 	@Override

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/TcpMatcher.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/TcpMatcher.java
@@ -107,7 +107,7 @@ public final class TcpMatcher extends BaseMatcher {
 		}
 		exchange.setRemoveHandler(exchangeRemoveHandler);
 		exchangeStore.registerOutboundRequestWithTokenOnly(exchange);
-		LOGGER.debug("tracking open request using {}", request.getTokenString());
+		LOGGER.trace("tracking open request using {}", request.getTokenString());
 	}
 
 	@Override

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/UdpMatcher.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/UdpMatcher.java
@@ -120,7 +120,7 @@ public final class UdpMatcher extends BaseMatcher {
 			if (exchangeStore.assignMessageId(request) != Message.NONE) {
 				registerObserve(request);
 			} else {
-				LOGGER.warn("message IDs exhausted, could not register outbound observe request for tracking");
+				LOGGER.debug("message IDs exhausted, could not register outbound observe request for tracking");
 				request.setSendError(new IllegalStateException("automatic message IDs exhausted"));
 				return;
 			}
@@ -131,7 +131,7 @@ public final class UdpMatcher extends BaseMatcher {
 				exchange.setRemoveHandler(exchangeRemoveHandler);
 				LOGGER.debug("tracking open request [MID: {}, Token: {}]", request.getMID(), request.getToken());
 			} else {
-				LOGGER.warn("message IDs exhausted, could not register outbound request for tracking");
+				LOGGER.debug("message IDs exhausted, could not register outbound request for tracking");
 				request.setSendError(new IllegalStateException("automatic message IDs exhausted"));
 			}
 		} catch (IllegalArgumentException ex) {

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/deduplication/DeduplicatorFactory.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/deduplication/DeduplicatorFactory.java
@@ -79,7 +79,7 @@ public class DeduplicatorFactory {
 		case NetworkConfig.Keys.NO_DEDUPLICATOR:
 			return new NoDeduplicator();
 		default:
-			LOGGER.warn("configuration contains unsupported deduplicator type, duplicate detection will be turned off");
+			LOGGER.trace("configuration contains unsupported deduplicator type, duplicate detection will be turned off");
 			return new NoDeduplicator();
 		}
 	}

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/interceptors/MessageTracer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/interceptors/MessageTracer.java
@@ -40,31 +40,31 @@ public class MessageTracer implements MessageInterceptor {
 
 	@Override
 	public void sendRequest(Request request) {
-		LOGGER.info("{} <== req {}", new Object[]{request.getDestinationContext(), request});
+		LOGGER.trace("{} <== req {}", new Object[]{request.getDestinationContext(), request});
 	}
 
 	@Override
 	public void sendResponse(Response response) {
-		LOGGER.info("{} <== res {}", new Object[]{response.getDestinationContext(), response});
+		LOGGER.trace("{} <== res {}", new Object[]{response.getDestinationContext(), response});
 	}
 
 	@Override
 	public void sendEmptyMessage(EmptyMessage message) {
-		LOGGER.info("{} <== emp {}", new Object[]{message.getDestinationContext(), message});
+		LOGGER.trace("{} <== emp {}", new Object[]{message.getDestinationContext(), message});
 	}
 
 	@Override
 	public void receiveRequest(Request request) {
-		LOGGER.info("{} ==> req {}", new Object[]{request.getSourceContext(), request});
+		LOGGER.trace("{} ==> req {}", new Object[]{request.getSourceContext(), request});
 	}
 
 	@Override
 	public void receiveResponse(Response response) {
-		LOGGER.info("{} ==> res {}", new Object[]{response.getSourceContext(), response});
+		LOGGER.trace("{} ==> res {}", new Object[]{response.getSourceContext(), response});
 	}
 
 	@Override
 	public void receiveEmptyMessage(EmptyMessage message) {
-		LOGGER.info("{} ==> emp {}", new Object[]{message.getSourceContext(), message});
+		LOGGER.trace("{} ==> emp {}", new Object[]{message.getSourceContext(), message});
 	}
 }

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/AbstractLayer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/AbstractLayer.java
@@ -192,12 +192,12 @@ public abstract class AbstractLayer implements Layer {
 
 		@Override
 		public void sendRequest(final Exchange exchange, final Request request) {
-			LOGGER.error("No lower layer set for sending request [{}]", request);
+			LOGGER.trace("No lower layer set for sending request [{}]", request);
 		}
 
 		@Override
 		public void sendResponse(final Exchange exchange, final Response response) {
-			LOGGER.error("No lower layer set for sending response [{}]", response);
+			LOGGER.trace("No lower layer set for sending response [{}]", response);
 		}
 
 		@Override
@@ -207,7 +207,7 @@ public abstract class AbstractLayer implements Layer {
 
 		@Override
 		public void receiveRequest(final Exchange exchange, final Request request) {
-			LOGGER.error("No upper layer set for receiving request [{}]", request);
+			LOGGER.trace("No upper layer set for receiving request [{}]", request);
 		}
 
 		@Override

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BaseCoapStack.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BaseCoapStack.java
@@ -209,7 +209,7 @@ public abstract class BaseCoapStack implements CoapStack {
 				// notify request that response has arrived
 				deliverer.deliverResponse(exchange, response);
 			} else {
-				LOGGER.error("Top of CoAP stack has no deliverer to deliver response");
+				LOGGER.info("Top of CoAP stack has no deliverer to deliver response");
 			}
 		}
 

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/Block2BlockwiseStatus.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/Block2BlockwiseStatus.java
@@ -149,7 +149,7 @@ public final class Block2BlockwiseStatus extends BlockwiseStatus {
 				return block2.getSzx();
 			}
 		}
-		LOGGER.debug("using default preferred block size for response: {}", preferredBlockSize);
+		LOGGER.trace("using default preferred block size for response: {}", preferredBlockSize);
 		return BlockOption.size2Szx(preferredBlockSize);
 	}
 

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BlockwiseLayer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BlockwiseLayer.java
@@ -428,7 +428,7 @@ public class BlockwiseLayer extends AbstractLayer {
 
 			if (block1.getNum() != status.getCurrentNum()) {
 				// ERROR, wrong number, Incomplete
-				LOGGER.warn(
+				LOGGER.debug(
 						"peer sent wrong block, expected no. {} but got {}. Responding with 4.08 (Request Entity Incomplete)",
 						status.getCurrentNum(), block1.getNum());
 
@@ -828,12 +828,12 @@ public class BlockwiseLayer extends AbstractLayer {
 			// ongoing blockwise transfer
 			if (starting) {
 				if (status.isNew(response)) {
-					LOGGER.debug("discarding outdated block2 transfer {}, current is [{}]", status.getObserve(),
+					LOGGER.trace("discarding outdated block2 transfer {}, current is [{}]", status.getObserve(),
 							response);
 					clearBlock2Status(key, status);
 					status.completeOldTransfer(exchange);
 				} else {
-					LOGGER.debug("discarding old block2 transfer [{}], received during ongoing block2 transfer {}",
+					LOGGER.trace("discarding old block2 transfer [{}], received during ongoing block2 transfer {}",
 							response, status.getObserve());
 					status.completeNewTranfer(exchange);
 					return true;
@@ -1080,7 +1080,7 @@ public class BlockwiseLayer extends AbstractLayer {
 		Block1BlockwiseStatus newStatus;
 		synchronized (block1Transfers) {
 			removedStatus = block1Transfers.remove(key);
-			LOGGER.warn("inbound block1 transfer reset at {} by peer: {}", removedStatus, request);
+			LOGGER.info("inbound block1 transfer reset at {} by peer: {}", removedStatus, request);
 			// remove old status ensures, that getInboundBlock1Status could be
 			// called in synchronized (block1Transfers)
 			newStatus = getInboundBlock1Status(key, exchange, request);
@@ -1150,7 +1150,7 @@ public class BlockwiseLayer extends AbstractLayer {
 			LOGGER.debug("stop previous block transfer {} {} for new {}", key, previousStatus, response);
 			previousStatus.completeResponse();
 		} else {
-			LOGGER.debug("block transfer {} for {}", key, response);
+			LOGGER.trace("block transfer {} for {}", key, response);
 		}
 		return newStatus;
 	}

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/CleanupMessageObserver.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/CleanupMessageObserver.java
@@ -54,10 +54,10 @@ public class CleanupMessageObserver extends MessageObserverAdapter {
 		if (exchange.executeComplete()) {
 			if (exchange.isOfLocalOrigin()) {
 				Request request = exchange.getCurrentRequest();
-				LOGGER.debug("{}, {} request [MID={}, {}]", action, exchange, request.getMID(), request.getToken());
+				LOGGER.trace("{}, {} request [MID={}, {}]", action, exchange, request.getMID(), request.getToken());
 			} else {
 				Response response = exchange.getCurrentResponse();
-				LOGGER.debug("{}, {} response [MID={}, {}]", action, exchange, response.getMID(), response.getToken());
+				LOGGER.trace("{}, {} response [MID={}, {}]", action, exchange, response.getMID(), response.getToken());
 			}
 		}
 	}

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/CongestionControlLayer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/CongestionControlLayer.java
@@ -482,7 +482,7 @@ public abstract class CongestionControlLayer extends ReliabilityLayer {
 		case "PeakhopperRto":
 			return new PeakhopperRto(config);
 		default:
-			LOGGER.info(
+			LOGGER.trace(
 				"configuration contains unsupported {}, using Cocoa",
 				NetworkConfig.Keys.CONGESTION_CONTROL_ALGORITHM);
 			return new Cocoa(config);

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/ObserveLayer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/ObserveLayer.java
@@ -141,7 +141,7 @@ public class ObserveLayer extends AbstractLayer {
 
 		if (response.isNotification() && exchange.getRequest().isCanceled()) {
 			// The request was canceled and we no longer want notifications
-			LOGGER.debug("rejecting notification for canceled Exchange");
+			LOGGER.trace("rejecting notification for canceled Exchange");
 			EmptyMessage rst = EmptyMessage.newRST(response);
 			sendEmptyMessage(exchange, rst);
 			// Matcher sets exchange as complete when RST is sent
@@ -228,7 +228,7 @@ public class ObserveLayer extends AbstractLayer {
 		@Override
 		public void onTimeout() {
 			ObserveRelation relation = exchange.getRelation();
-			LOGGER.info("notification for token [{}] timed out. Canceling all relations with source [{}]",
+			LOGGER.debug("notification for token [{}] timed out. Canceling all relations with source [{}]",
 					relation.getExchange().getRequest().getToken(), relation.getSource());
 			relation.cancelAll();
 		}

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/ReliabilityLayer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/ReliabilityLayer.java
@@ -88,7 +88,7 @@ public class ReliabilityLayer extends AbstractLayer {
 	@Override
 	public void sendRequest(final Exchange exchange, final Request request) {
 
-		LOGGER.debug("{} send request, failed transmissions: {}", exchange, exchange.getFailedTransmissionCount());
+		LOGGER.severe("{} send request, failed transmissions: {}", exchange, exchange.getFailedTransmissionCount());
 
 		if (request.getType() == null) {
 			request.setType(Type.CON);
@@ -114,7 +114,7 @@ public class ReliabilityLayer extends AbstractLayer {
 	@Override
 	public void sendResponse(final Exchange exchange, final Response response) {
 
-		LOGGER.debug("{} send response {}, failed transmissions: {}", exchange, response,
+		LOGGER.severe("{} send response {}, failed transmissions: {}", exchange, response,
 				exchange.getFailedTransmissionCount());
 
 		// If a response type is set, we do not mess around with it.
@@ -231,7 +231,7 @@ public class ReliabilityLayer extends AbstractLayer {
 						// retransmission cycle
 						int failedCount = exchange.getFailedTransmissionCount() + 1;
 						exchange.setFailedTransmissionCount(failedCount);
-						LOGGER.debug("{} request duplicate: retransmit response, failed: {}, response: {}", exchange,
+						LOGGER.severe("{} request duplicate: retransmit response, failed: {}, response: {}", exchange,
 								failedCount, currentResponse);
 						currentResponse.retransmitting();
 						sendResponse(exchange, currentResponse);
@@ -445,7 +445,7 @@ public class ReliabilityLayer extends AbstractLayer {
 				int failedCount = exchange.getFailedTransmissionCount() + 1;
 				exchange.setFailedTransmissionCount(failedCount);
 
-				LOGGER.debug("Timeout: for {} retry {} of {}", exchange, failedCount, message);
+				LOGGER.warn("Timeout: for {} retry {} of {}", exchange, failedCount, message);
 
 				if (message.isAcknowledged()) {
 					LOGGER.trace("Timeout: for {} message already acknowledged, cancel retransmission of {}", exchange,
@@ -462,7 +462,7 @@ public class ReliabilityLayer extends AbstractLayer {
 					return;
 
 				} else if (failedCount <= getReliabilityLayerParameters().getMaxRetransmit()) {
-					LOGGER.debug("Timeout: for {} retransmit message, failed: {}, message: {}", exchange, failedCount,
+					LOGGER.warn("Timeout: for {} retransmit message, failed: {}, message: {}", exchange, failedCount,
 							message);
 
 					// Trigger MessageObservers

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/TcpObserveLayer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/TcpObserveLayer.java
@@ -71,7 +71,7 @@ public class TcpObserveLayer extends AbstractLayer {
 	public void receiveResponse(final Exchange exchange, final Response response) {
 		if (response.getOptions().hasObserve() && exchange.getRequest().isCanceled()) {
 			// The request was canceled and we no longer want notifications
-			LOGGER.debug("ignoring notification for canceled TCP Exchange");
+			LOGGER.trace("ignoring notification for canceled TCP Exchange");
 		} else {
 			// No observe option in response => always deliver
 			upper().receiveResponse(exchange, response);

--- a/californium-core/src/main/java/org/eclipse/californium/core/observe/InMemoryObservationStore.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/observe/InMemoryObservationStore.java
@@ -71,9 +71,9 @@ public final class InMemoryObservationStore implements ObservationStore {
 			enableStatus = true;
 			Observation result = map.putIfAbsent(key, obs);
 			if (result == null) {
-				LOGGER.debug("added observation for {}", key);
+				LOGGER.trace("added observation for {}", key);
 			} else {
-				LOGGER.debug("kept observation {} for {}", result, key);
+				LOGGER.trace("kept observation {} for {}", result, key);
 			}
 			return result;
 		}
@@ -89,9 +89,9 @@ public final class InMemoryObservationStore implements ObservationStore {
 			enableStatus = true;
 			Observation result = map.put(key, obs);
 			if (result == null) {
-				LOGGER.debug("added observation for {}", key);
+				LOGGER.trace("added observation for {}", key);
 			} else {
-				LOGGER.debug("replaced observation {} for {}", result, key);
+				LOGGER.trace("replaced observation {} for {}", result, key);
 			}
 			return result;
 		}
@@ -103,7 +103,7 @@ public final class InMemoryObservationStore implements ObservationStore {
 			return null;
 		} else {
 			Observation obs = map.get(token);
-			LOGGER.debug("looking up observation for token {}: {}", token, obs);
+			LOGGER.trace("looking up observation for token {}: {}", token, obs);
 			// clone request in order to prevent accumulation of
 			// message observers on original request
 			return ObservationUtil.shallowClone(obs);
@@ -114,7 +114,7 @@ public final class InMemoryObservationStore implements ObservationStore {
 	public void remove(Token token) {
 		if (token != null) {
 			if (map.remove(token) != null) {
-				LOGGER.debug("removed observation for token {}", token);
+				LOGGER.trace("removed observation for token {}", token);
 			} else {
 				LOGGER.debug("Already removed observation for token {}", token);
 			}

--- a/californium-core/src/main/java/org/eclipse/californium/core/server/ServerMessageDeliverer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/server/ServerMessageDeliverer.java
@@ -108,7 +108,7 @@ public class ServerMessageDeliverer implements MessageDeliverer {
 					resource.handleRequest(exchange);
 				}
 			} else {
-				LOGGER.info("did not find resource {} requested by {}", path,
+				LOGGER.debug("did not find resource {} requested by {}", path,
 						request.getSourceContext().getPeerAddress());
 				exchange.sendResponse(new Response(ResponseCode.NOT_FOUND));
 			}

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/CountingCoapHandler.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/CountingCoapHandler.java
@@ -74,7 +74,7 @@ public class CountingCoapHandler implements CoapHandler {
 			}
 			notifyAll();
 		}
-		LOGGER.info("Received {}. Notification: {}", counter, response.advanced());
+		LOGGER.trace("Received {}. Notification: {}", counter, response.advanced());
 	}
 
 	/**

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/MemoryLeakingHashMapTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/MemoryLeakingHashMapTest.java
@@ -521,7 +521,7 @@ public class MemoryLeakingHashMapTest {
 				return;
 			}
 
-			LOGGER.debug("Client received notification {}: [{}]", counter, response.getResponseText());
+			LOGGER.trace("Client received notification {}: [{}]", counter, response.getResponseText());
 
 			if (cancelProactively) {
 				if ((counter + 1) == expectedNotifies) {

--- a/californium-osgi/src/main/java/org/eclipse/californium/osgi/ManagedServer.java
+++ b/californium-osgi/src/main/java/org/eclipse/californium/osgi/ManagedServer.java
@@ -216,7 +216,7 @@ public class ManagedServer implements ManagedService, ServiceTrackerCustomizer<R
 	@Override
 	public Resource addingService(ServiceReference<Resource> reference) {
 		Resource resource = context.getService(reference);
-		LOGGER.debug("Adding resource [{}]", resource.getName());
+		LOGGER.trace("Adding resource [{}]", resource.getName());
 		if (resource != null) {
 			managedServer.add(resource);
 		}
@@ -235,7 +235,7 @@ public class ManagedServer implements ManagedService, ServiceTrackerCustomizer<R
 	@Override
 	public void removedService(ServiceReference<Resource> reference,
 			Resource service) {
-		LOGGER.debug("Removing resource [{}]", service.getName());
+		LOGGER.trace("Removing resource [{}]", service.getName());
 		managedServer.remove(service);
 		context.ungetService(reference);
 	}

--- a/californium-proxy/src/main/java/org/eclipse/californium/proxy/CoapTranslator.java
+++ b/californium-proxy/src/main/java/org/eclipse/californium/proxy/CoapTranslator.java
@@ -128,7 +128,7 @@ public final class CoapTranslator {
 			outgoingRequest.setURI(serverUri);
 		}
 
-		LOGGER.debug("Incoming request translated correctly");
+		LOGGER.trace("Incoming request translated correctly");
 		return outgoingRequest;
 	}
 	

--- a/californium-proxy/src/main/java/org/eclipse/californium/proxy/DirectProxyCoapResolver.java
+++ b/californium-proxy/src/main/java/org/eclipse/californium/proxy/DirectProxyCoapResolver.java
@@ -47,7 +47,7 @@ public class DirectProxyCoapResolver implements ProxyCoapResolver {
 
 	@Override
 	public void forwardRequest(Exchange exchange) {
-		LOGGER.debug("Forward CoAP request to ProxyCoap2Coap: {}", exchange.getRequest());
+		LOGGER.trace("Forward CoAP request to ProxyCoap2Coap: {}", exchange.getRequest());
 		proxyCoapClientResource.handleRequest(exchange);
 	}
 }

--- a/californium-proxy/src/main/java/org/eclipse/californium/proxy/HttpRequestContext.java
+++ b/californium-proxy/src/main/java/org/eclipse/californium/proxy/HttpRequestContext.java
@@ -64,7 +64,7 @@ public final class HttpRequestContext {
 			// translate the coap response in an http response
 			new HttpTranslator().getHttpResponse(httpRequest, coapResponse, httpResponse);
 
-			LOGGER.debug("Outgoing http response: {}", httpResponse.getStatusLine());
+			LOGGER.trace("Outgoing http response: {}", httpResponse.getStatusLine());
 		} catch (TranslationException e) {
 			LOGGER.warn("Failed to translate coap response to http response: {}", e.getMessage());
 			sendSimpleHttpResponse(HttpTranslator.STATUS_TRANSLATION_ERROR);

--- a/californium-proxy/src/main/java/org/eclipse/californium/proxy/HttpStack.java
+++ b/californium-proxy/src/main/java/org/eclipse/californium/proxy/HttpStack.java
@@ -240,7 +240,7 @@ public class HttpStack {
 				httpResponse.setEntity(new StringEntity("Californium Proxy server"));
 
 //				if (Bench_Help.DO_LOG) 
-					LOGGER.debug("Root request handled");
+					LOGGER.trace("Root request handled");
 			}
 		}
 

--- a/californium-proxy/src/main/java/org/eclipse/californium/proxy/ProxyHttpServer.java
+++ b/californium-proxy/src/main/java/org/eclipse/californium/proxy/ProxyHttpServer.java
@@ -106,7 +106,7 @@ public class ProxyHttpServer {
 				request.setResponse(response);
 				responseProduced(request, response);
 				context.handleRequestForwarding(response);
-				LOGGER.info("HTTP returned {}", response);
+				LOGGER.trace("HTTP returned {}", response);
 			}
 		};
 		exchange.setRequest(request);
@@ -184,7 +184,7 @@ public class ProxyHttpServer {
 			clientPath = PROXY_COAP_CLIENT;
 		}
 
-		LOGGER.info("Chose {} as clientPath", clientPath);
+		LOGGER.trace("Chose {} as clientPath", clientPath);
 
 		// set the path in the request to be forwarded correctly
 		request.getOptions().setUriPath(clientPath);

--- a/californium-proxy/src/main/java/org/eclipse/californium/proxy/resources/ProxyCacheResource.java
+++ b/californium-proxy/src/main/java/org/eclipse/californium/proxy/resources/ProxyCacheResource.java
@@ -162,7 +162,7 @@ public class ProxyCacheResource extends CoapResource implements CacheResource {
 
 					LOGGER.debug("Updated cached response");
 				} else {
-					LOGGER.warn("No max-age option set in response: {}", response);
+					LOGGER.info("No max-age option set in response: {}", response);
 				}
 			} else if (code == ResponseCode.CONTENT) {
 				// set max-age if not set
@@ -196,7 +196,7 @@ public class ProxyCacheResource extends CoapResource implements CacheResource {
 				}
 			} else {
 				// this code should not be reached
-				LOGGER.error("Code not recognized: {}", code);
+				LOGGER.info("Code not recognized: {}", code);
 			}
 		}
 	}
@@ -266,7 +266,7 @@ public class ProxyCacheResource extends CoapResource implements CacheResource {
 	@Override
 	public void invalidateRequest(Request request) {
 		invalidateRequest(CacheKey.fromAcceptOptions(request));
-		LOGGER.debug("Invalidated request");
+		LOGGER.trace("Invalidated request");
 	}
 
 	@Override

--- a/californium-proxy/src/main/java/org/eclipse/californium/proxy/resources/ProxyCoapClientResource.java
+++ b/californium-proxy/src/main/java/org/eclipse/californium/proxy/resources/ProxyCoapClientResource.java
@@ -80,28 +80,28 @@ public class ProxyCoapClientResource extends ForwardingResource {
 
 				@Override
 				public void onResponse(Response incomingResponse) {
-					LOGGER.debug("ProxyCoapClientResource received {}", incomingResponse);
+					LOGGER.trace("ProxyCoapClientResource received {}", incomingResponse);
 					future.complete(CoapTranslator.getResponse(incomingResponse));
 					EndPointManagerPool.putClient(endpointManager);
 				}
 
 				@Override
 				public void onReject() {
-					LOGGER.warn("Request rejected");
+					LOGGER.trace("Request rejected");
 					future.complete(new Response(ResponseCode.SERVICE_UNAVAILABLE));
 					EndPointManagerPool.putClient(endpointManager);
 				}
 
 				@Override
 				public void onTimeout() {
-					LOGGER.warn("Request timed out.");
+					LOGGER.trace("Request timed out.");
 					future.complete(new Response(ResponseCode.GATEWAY_TIMEOUT));
 					EndPointManagerPool.putClient(endpointManager);
 				}
 
 				@Override
 				public void onCancel() {
-					LOGGER.warn("Request canceled");
+					LOGGER.trace("Request canceled");
 					future.complete(new Response(ResponseCode.SERVICE_UNAVAILABLE));
 					EndPointManagerPool.putClient(endpointManager);
 				}

--- a/californium-proxy/src/main/java/org/eclipse/californium/proxy/resources/ProxyHttpClientResource.java
+++ b/californium-proxy/src/main/java/org/eclipse/californium/proxy/resources/ProxyHttpClientResource.java
@@ -146,7 +146,7 @@ public class ProxyHttpClientResource extends ForwardingResource {
 
 			@Override
 			public void cancelled() {
-				LOGGER.warn("Request canceled");
+				LOGGER.trace("Request canceled");
 				future.complete(new Response(ResponseCode.SERVICE_UNAVAILABLE));
 			}
 		});

--- a/cf-oscore/src/main/java/org/eclipse/californium/oscore/ContextRederivation.java
+++ b/cf-oscore/src/main/java/org/eclipse/californium/oscore/ContextRederivation.java
@@ -423,9 +423,9 @@ public class ContextRederivation {
 
 		String output = "Context re-derivation phase: " + currentPhase + " (" + supplemental + ")";
 		if (currentPhase == PHASE.INACTIVE) {
-			LOGGER.debug(output);
+			LOGGER.trace(output);
 		} else {
-			LOGGER.info(output);
+			LOGGER.trace(output);
 		}
 	}
 

--- a/cf-oscore/src/main/java/org/eclipse/californium/oscore/Decryptor.java
+++ b/cf-oscore/src/main/java/org/eclipse/californium/oscore/Decryptor.java
@@ -157,7 +157,7 @@ public abstract class Decryptor {
 	 */
 	private static byte[] expandToIntSize(byte[] partialIV) throws OSException {
 		if (partialIV.length > INTEGER_BYTES) {
-			LOGGER.error("The partial IV is: " + partialIV.length + " long, " + INTEGER_BYTES + " was expected");
+			LOGGER.trace("The partial IV is: " + partialIV.length + " long, " + INTEGER_BYTES + " was expected");
 			throw new OSException("Partial IV too long");
 		} else if (partialIV.length == INTEGER_BYTES) {
 			return partialIV;

--- a/cf-oscore/src/main/java/org/eclipse/californium/oscore/OSCoreCtx.java
+++ b/cf-oscore/src/main/java/org/eclipse/californium/oscore/OSCoreCtx.java
@@ -623,7 +623,7 @@ public class OSCoreCtx {
 				id_length = 7;
 				key_length = common_alg.getKeySize() / 8; // 16;
 			} else {
-				LOGGER.error("Unable to set lengths, since algorithm");
+				LOGGER.trace("Unable to set lengths, since algorithm");
 				throw new RuntimeException("Unable to set lengths, since algorithm");
 			}
 		} else {

--- a/cf-oscore/src/main/java/org/eclipse/californium/oscore/ObjectSecurityContextLayer.java
+++ b/cf-oscore/src/main/java/org/eclipse/californium/oscore/ObjectSecurityContextLayer.java
@@ -97,7 +97,7 @@ public class ObjectSecurityContextLayer extends AbstractLayer {
 
 								@Override
 								public void run() {
-									LOGGER.info("Original Request: " + exchange.getRequest().toString());
+									LOGGER.trace("Original Request: " + exchange.getRequest().toString());
 									ObjectSecurityContextLayer.super.sendRequest(exchange, request);
 								}
 							});
@@ -141,7 +141,7 @@ public class ObjectSecurityContextLayer extends AbstractLayer {
 
 					});
 					// send start rederivation request
-					LOGGER.info("Auxiliary Request: " + exchange.getRequest().toString());
+					LOGGER.debug("Auxiliary Request: " + exchange.getRequest().toString());
 					final Exchange newExchange = new Exchange(startRederivation, Origin.LOCAL, executor);
 					newExchange.execute(new Runnable() {
 
@@ -161,7 +161,7 @@ public class ObjectSecurityContextLayer extends AbstractLayer {
 				return;
 			}
 		}
-		LOGGER.info("Request: " + exchange.getRequest().toString());
+		LOGGER.debug("Request: " + exchange.getRequest().toString());
 		super.sendRequest(exchange, request);
 	}
 

--- a/demo-apps/cf-extplugtest-client/src/main/java/org/eclipse/californium/extplugtests/BenchmarkClient.java
+++ b/demo-apps/cf-extplugtest-client/src/main/java/org/eclipse/californium/extplugtests/BenchmarkClient.java
@@ -375,7 +375,7 @@ public class BenchmarkClient {
 					next();
 				}
 				long c = overallRequestsDownCounter.get();
-				LOGGER.info("Received response: {} {}", response.advanced(), c);
+				LOGGER.trace("Received response: {} {}", response.advanced(), c);
 			} else {
 				long c = requestsCounter.get();
 				LOGGER.warn("Received error response: {} {} ({} successful)", endpoint.getUri(), response.advanced(), c);
@@ -479,7 +479,7 @@ public class BenchmarkClient {
 			CoapResponse response = client.advanced(post);
 			if (response != null) {
 				if (response.isSuccess()) {
-					LOGGER.info("Received response: {}", response.advanced());
+					LOGGER.trace("Received response: {}", response.advanced());
 					clientCounter.incrementAndGet();
 					checkReady(true, true);
 					return true;
@@ -487,7 +487,7 @@ public class BenchmarkClient {
 					LOGGER.warn("Received error response: {} - {}", response.advanced().getCode(), response.advanced().getPayloadString());
 				}
 			} else {
-				LOGGER.warn("Received no response!");
+				LOGGER.trace("Received no response!");
 			}
 		} catch (Exception ex) {
 			LOGGER.warn("Test failed!", ex);
@@ -974,21 +974,21 @@ public class BenchmarkClient {
 		if (tag != null) {
 			// with tag, use file
 			logger = LoggerFactory.getLogger(logger.getName() + ".file");
-			logger.info("------- {} ------------------------------------------------", tag);
-			logger.info("{}, {}, {}", osMxBean.getName(), osMxBean.getVersion(), osMxBean.getArch());
+			logger.trace("------- {} ------------------------------------------------", tag);
+			logger.trace("{}, {}, {}", osMxBean.getName(), osMxBean.getVersion(), osMxBean.getArch());
 			StringBuilder line = new StringBuilder();
 			List<String> vmArgs = ManagementFactory.getRuntimeMXBean().getInputArguments();
 			for (String arg : vmArgs) {
 				line.append(arg).append(" ");
 			}
-			logger.info("{}", line);
+			logger.trace("{}", line);
 			line.setLength(0);
 			for (String arg : args) {
 				line.append(arg).append(" ");
 			}
-			logger.info("{}", line);
+			logger.trace("{}", line);
 		}
-		logger.info("uptime: {} ms, {} processors", TimeUnit.NANOSECONDS.toMillis(uptimeNanos), processors);
+		logger.trace("uptime: {} ms, {} processors", TimeUnit.NANOSECONDS.toMillis(uptimeNanos), processors);
 		ThreadMXBean threadMxBean = ManagementFactory.getThreadMXBean();
 		if (threadMxBean.isThreadCpuTimeSupported() && threadMxBean.isThreadCpuTimeEnabled()) {
 			long alltime = 0;
@@ -1000,7 +1000,7 @@ public class BenchmarkClient {
 				}
 			}
 			long pTime = alltime / processors;
-			logger.info("cpu-time: {} ms (per-processor: {} ms, load: {}%)",
+			logger.trace("cpu-time: {} ms (per-processor: {} ms, load: {}%)",
 					TimeUnit.NANOSECONDS.toMillis(alltime), TimeUnit.NANOSECONDS.toMillis(pTime),
 					(pTime * 100) / uptimeNanos);
 		}
@@ -1016,7 +1016,7 @@ public class BenchmarkClient {
 				gcTime += time;
 			}
 		}
-		logger.info("gc: {} ms, {} calls", gcTime, gcCount);
+		logger.trace("gc: {} ms, {} calls", gcTime, gcCount);
 		double loadAverage = osMxBean.getSystemLoadAverage();
 		if (!(loadAverage < 0.0d)) {
 			logger.info("average load: {}", String.format("%.2f", loadAverage));

--- a/demo-apps/cf-extplugtest-client/src/main/java/org/eclipse/californium/extplugtests/resources/Feed.java
+++ b/demo-apps/cf-extplugtest-client/src/main/java/org/eclipse/californium/extplugtests/resources/Feed.java
@@ -116,7 +116,7 @@ public class Feed extends CoapResource {
 		@Override
 		public void run() {
 			changeScheduled.set(false);
-			LOGGER.info("client[{}] feed change triggered, {} observers", id, getObserverCount());
+			LOGGER.trace("client[{}] feed change triggered, {} observers", id, getObserverCount());
 			changed();
 		}
 	};
@@ -219,14 +219,14 @@ public class Feed extends CoapResource {
 							response.getToken());
 				} else {
 					timeout = 0;
-					LOGGER.info("client[{}] next change in {} ms, {} observer.", id, interval, observer);
+					LOGGER.trace("client[{}] next change in {} ms, {} observer.", id, interval, observer);
 					executorService.schedule(change, interval, TimeUnit.MILLISECONDS);
 				}
 			} else {
-				LOGGER.info("client[{}] pending change, {} observer, send {}!", id, observer, response.getToken());
+				LOGGER.trace("client[{}] pending change, {} observer, send {}!", id, observer, response.getToken());
 			}
 		} else {
-			LOGGER.info("client[{}] no observe {}!", id, request);
+			LOGGER.trace("client[{}] no observe {}!", id, request);
 		}
 		response.addMessageObserver(new MessageCompletionObserver(timeout, interval));
 		exchange.respond(response);
@@ -289,11 +289,11 @@ public class Feed extends CoapResource {
 				timeoutJob.cancel(false);
 			}
 			if (interval < 0) {
-				LOGGER.info("client[{}] response {}, next change in {} ms, {} observer.", id, state, -interval,
+				LOGGER.trace("client[{}] response {}, next change in {} ms, {} observer.", id, state, -interval,
 						getObserverCount());
 				executorService.schedule(change, -interval, TimeUnit.MILLISECONDS);
 			} else {
-				LOGGER.info("client[{}] response {}, {} observer.", id, state, getObserverCount());
+				LOGGER.trace("client[{}] response {}, {} observer.", id, state, getObserverCount());
 			}
 		}
 	}

--- a/demo-apps/cf-extplugtest-server/src/main/java/org/eclipse/californium/extplugtests/ExtendedTestServer.java
+++ b/demo-apps/cf-extplugtest-server/src/main/java/org/eclipse/californium/extplugtests/ExtendedTestServer.java
@@ -231,7 +231,7 @@ public class ExtendedTestServer extends AbstractTestServer {
 		OperatingSystemMXBean osMxBean = ManagementFactory.getOperatingSystemMXBean();
 		int processors = osMxBean.getAvailableProcessors();
 		Logger logger = STATISTIC_LOGGER;
-		logger.info("{} processors", processors);
+		logger.trace("{} processors", processors);
 		ThreadMXBean threadMxBean = ManagementFactory.getThreadMXBean();
 		if (threadMxBean.isThreadCpuTimeSupported() && threadMxBean.isThreadCpuTimeEnabled()) {
 			long alltime = 0;
@@ -243,7 +243,7 @@ public class ExtendedTestServer extends AbstractTestServer {
 				}
 			}
 			long pTime = alltime / processors;
-			logger.info("cpu-time: {} ms (per-processor: {} ms)",
+			logger.trace("cpu-time: {} ms (per-processor: {} ms)",
 					TimeUnit.NANOSECONDS.toMillis(alltime), TimeUnit.NANOSECONDS.toMillis(pTime));
 		}
 		long gcCount = 0;
@@ -258,7 +258,7 @@ public class ExtendedTestServer extends AbstractTestServer {
 				gcTime += time;
 			}
 		}
-		logger.info("gc: {} ms, {} calls", gcTime, gcCount);
+		logger.trace("gc: {} ms, {} calls", gcTime, gcCount);
 		double loadAverage = osMxBean.getSystemLoadAverage();
 		if (!(loadAverage < 0.0d)) {
 			logger.info("average load: {}", String.format("%.2f", loadAverage));

--- a/demo-apps/cf-extplugtest-server/src/main/java/org/eclipse/californium/extplugtests/resources/ReverseObserve.java
+++ b/demo-apps/cf-extplugtest-server/src/main/java/org/eclipse/californium/extplugtests/resources/ReverseObserve.java
@@ -189,7 +189,7 @@ public class ReverseObserve extends CoapResource implements NotificationListener
 			ObservationRequest pendingObservation = observesByPeer.putIfAbsent(key,
 					new ObservationRequest(exchange, Token.EMPTY));
 			if (pendingObservation != null && pendingObservation.getObservationToken().equals(Token.EMPTY)) {
-				LOGGER.warn("Too many requests from {} (pending {}, current {})", key,
+				LOGGER.trace("Too many requests from {} (pending {}, current {})", key,
 						pendingObservation.getIncomingExchange().getRequest().getMID(), request.getMID());
 				exchange.respond(SERVICE_UNAVAILABLE);
 			} else {
@@ -210,11 +210,11 @@ public class ReverseObserve extends CoapResource implements NotificationListener
 					overallObserves.incrementAndGet();
 				} else {
 					if (pendingObservation != null) {
-						LOGGER.info("Requested cancel observation {}", pendingObservation.getObservationToken());
+						LOGGER.trace("Requested cancel observation {}", pendingObservation.getObservationToken());
 						endpoint.cancelObservation(pendingObservation.getObservationToken());
 						exchange.respond(CHANGED);
 					} else {
-						LOGGER.info("Requested cancel not established observation for {}", key);
+						LOGGER.trace("Requested cancel not established observation for {}", key);
 						exchange.respond(CHANGED);
 					}
 				}
@@ -235,9 +235,9 @@ public class ReverseObserve extends CoapResource implements NotificationListener
 		} else {
 			String peer = peersByToken.get(token);
 			if (peer != null) {
-				LOGGER.info("Notification {} from old observe: {}", response, peer);
+				LOGGER.trace("Notification {} from old observe: {}", response, peer);
 			} else {
-				LOGGER.info("Notification {} from unkown observe", response);
+				LOGGER.trace("Notification {} from unkown observe", response);
 			}
 		}
 	}
@@ -429,7 +429,7 @@ public class ReverseObserve extends CoapResource implements NotificationListener
 		private void remove(ResponseCode code) {
 			String key = incomingExchange.getPeerKey();
 			observesByPeer.remove(key);
-			LOGGER.info("Removed observation for {}", key);
+			LOGGER.trace("Removed observation for {}", key);
 			incomingExchange.respond(code);
 		}
 	}
@@ -496,7 +496,7 @@ public class ReverseObserve extends CoapResource implements NotificationListener
 
 		private void reregister() {
 			String key = incomingExchange.getPeerKey();
-			LOGGER.info("Cancel observation {} for {}", observationToken, key);
+			LOGGER.trace("Cancel observation {} for {}", observationToken, key);
 			incomingExchange.getEndpoint().cancelObservation(observationToken);
 			observesByPeer.remove(key);
 			observesByToken.remove(observationToken, this);

--- a/demo-apps/cf-extplugtest-server/src/main/java/org/eclipse/californium/extplugtests/resources/ReverseRequest.java
+++ b/demo-apps/cf-extplugtest-server/src/main/java/org/eclipse/californium/extplugtests/resources/ReverseRequest.java
@@ -185,8 +185,8 @@ public class ReverseRequest extends CoapResource {
 			if (overallSentRequests.getAndIncrement() == 0) {
 				LOGGER.info("start reverse requests!");
 			}
-			LOGGER.debug("{}", request);
-			LOGGER.info("{}/{}: {} reverse requests, {} overall.", request.getSourceContext().getPeerAddress(),
+			LOGGER.trace("{}", request);
+			LOGGER.trace("{}/{}: {} reverse requests, {} overall.", request.getSourceContext().getPeerAddress(),
 					resource, numberOfRequests, overall);
 			Endpoint endpoint = exchange.advanced().getEndpoint();
 			exchange.respond(CHANGED);

--- a/demo-apps/cf-nat/src/main/java/org/eclipse/californium/examples/NatUtil.java
+++ b/demo-apps/cf-nat/src/main/java/org/eclipse/californium/examples/NatUtil.java
@@ -207,7 +207,7 @@ public class NatUtil implements Runnable {
 			int sent = sentMessages.get();
 			int manipulated = manipulatedMessages.get();
 			if (sent > 0) {
-				LOGGER.warn("manipulated {} {}/{}%, sent {} {}.", title, manipulated,
+				LOGGER.trace("manipulated {} {}/{}%, sent {} {}.", title, manipulated,
 						manipulated * 100 / (manipulated + sent), title, sent);
 			} else if (manipulated > 0) {
 				LOGGER.warn("manipulated {} {}/100%, no {} sent!.", title, manipulated, title);
@@ -446,10 +446,10 @@ public class NatUtil implements Runnable {
 		NatEntry entry = new NatEntry(incoming);
 		NatEntry old = nats.put(incoming, entry);
 		if (null != old) {
-			LOGGER.info("changed NAT for {} from {} to {}.", incoming, old.getPort(), entry.getPort());
+			LOGGER.trace("changed NAT for {} from {} to {}.", incoming, old.getPort(), entry.getPort());
 			old.stop();
 		} else {
-			LOGGER.info("add NAT for {} to {}.", incoming, entry.getPort());
+			LOGGER.trace("add NAT for {} to {}.", incoming, entry.getPort());
 		}
 		return entry.getPort();
 	}
@@ -489,7 +489,7 @@ public class NatUtil implements Runnable {
 		if (null != entry) {
 			entry.stop();
 		} else {
-			LOGGER.warn("no mapping found for {}!", incoming);
+			LOGGER.trace("no mapping found for {}!", incoming);
 		}
 		return null != entry;
 	}
@@ -505,7 +505,7 @@ public class NatUtil implements Runnable {
 		if (null != entry) {
 			return entry.getPort();
 		} else {
-			LOGGER.warn("no mapping found for {}!", incoming);
+			LOGGER.trace("no mapping found for {}!", incoming);
 			return -1;
 		}
 	}
@@ -521,7 +521,7 @@ public class NatUtil implements Runnable {
 		if (null != entry) {
 			return new InetSocketAddress(destination.getAddress(), entry.getPort());
 		} else {
-			LOGGER.warn("no mapping found for {}!", incoming);
+			LOGGER.trace("no mapping found for {}!", incoming);
 			return null;
 		}
 	}
@@ -556,7 +556,7 @@ public class NatUtil implements Runnable {
 		} else {
 			forward = new MessageDropping("request", percent);
 			backward = new MessageDropping("responses", percent);
-			LOGGER.info("NAT message dropping {}%.", percent);
+			LOGGER.trace("NAT message dropping {}%.", percent);
 		}
 	}
 
@@ -577,7 +577,7 @@ public class NatUtil implements Runnable {
 			}
 		} else {
 			forward = new MessageDropping("request", percent);
-			LOGGER.info("NAT forward message dropping {}%.", percent);
+			LOGGER.trace("NAT forward message dropping {}%.", percent);
 		}
 	}
 
@@ -598,7 +598,7 @@ public class NatUtil implements Runnable {
 			}
 		} else {
 			backward = new MessageDropping("response", percent);
-			LOGGER.info("NAT backward message dropping {}%.", percent);
+			LOGGER.trace("NAT backward message dropping {}%.", percent);
 		}
 	}
 
@@ -624,7 +624,7 @@ public class NatUtil implements Runnable {
 			}
 		} else {
 			reorder = new MessageReordering("reordering", percent, delayMillis, randomDelayMillis);
-			LOGGER.info("NAT message reordering {}%.", percent);
+			LOGGER.trace("NAT message reordering {}%.", percent);
 		}
 	}
 
@@ -763,10 +763,10 @@ public class NatUtil implements Runnable {
 			}
 			MessageDropping dropping = forward;
 			if (dropping != null && dropping.dropMessage()) {
-				LOGGER.info("forward drops {} bytes from {} to {} via {}", packet.getLength(), incomingName,
+				LOGGER.debug("forward drops {} bytes from {} to {} via {}", packet.getLength(), incomingName,
 						destinationName, natName);
 			} else {
-				LOGGER.info("forward {} bytes from {} to {} via {}", packet.getLength(), incomingName, destinationName,
+				LOGGER.debug("forward {} bytes from {} to {} via {}", packet.getLength(), incomingName, destinationName,
 						natName);
 				packet.setSocketAddress(destination);
 				lastUsage.set(System.nanoTime());

--- a/element-connector/src/main/java/org/eclipse/californium/elements/util/PemReader.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/util/PemReader.java
@@ -53,7 +53,7 @@ public class PemReader {
 			Matcher matcher = BEGIN_PATTERN.matcher(line);
 			if (matcher.matches()) {
 				tag = matcher.group(1);
-				LOGGER.debug("Found Begin of {}", tag);
+				LOGGER.trace("Found Begin of {}", tag);
 				break;
 			}
 		}
@@ -70,10 +70,10 @@ public class PemReader {
 				String end = matcher.group(1);
 				if (end.equals(tag)) {
 					byte[] decode = Base64.decode(buffer.toString());
-					LOGGER.debug("Found End of {}", tag);
+					LOGGER.trace("Found End of {}", tag);
 					return decode;
 				} else {
-					LOGGER.warn("Found End of {}, but expected {}!", end, tag);
+					LOGGER.trace("Found End of {}, but expected {}!", end, tag);
 					break;
 				}
 			}

--- a/element-connector/src/main/java/org/eclipse/californium/elements/util/SslContextUtil.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/util/SslContextUtil.java
@@ -840,7 +840,7 @@ public class SslContextUtil {
 						}
 						keys.setPublicKey(read);
 					} else {
-						LOGGER.warn("{} not supported!", tag);
+						LOGGER.trace("{} not supported!", tag);
 					}
 				}
 			}

--- a/element-connector/src/test/java/org/eclipse/californium/elements/UDPConnectorTest.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/UDPConnectorTest.java
@@ -197,7 +197,7 @@ public class UDPConnectorTest {
 		EndpointContext context = new UdpEndpointContext(dest);
 
 		for (int loop = 0; loop < loops; ++loop) {
-			LOGGER.info("start/stop: {}/{} loops, {} msgs", loop, loops, pending);
+			LOGGER.warn("start/stop: {}/{} loops, {} msgs", loop, loops, pending);
 			TestEndpointContextMatcher matcher = new TestEndpointContextMatcher(pending, pending);
 			connector.setEndpointContextMatcher(matcher);
 

--- a/element-connector/src/test/java/org/eclipse/californium/elements/rule/TestNameLoggerRule.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/rule/TestNameLoggerRule.java
@@ -29,6 +29,6 @@ public class TestNameLoggerRule extends TestWatcher {
 
 	@Override
 	protected void starting(Description description) {
-		LOGGER.info("Test {}", description.getMethodName());
+		LOGGER.trace("Test {}", description.getMethodName());
 	}
 }

--- a/element-connector/src/test/java/org/eclipse/californium/elements/rule/TestTimeRule.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/rule/TestTimeRule.java
@@ -60,7 +60,7 @@ public class TestTimeRule extends TestWatcher {
 	 * @param unit unit of time to add
 	 */
 	public final synchronized void addTestTimeShift(final long delta, final TimeUnit unit) {
-		LOGGER.debug("add {} {} to timeshift {} ns", delta, unit, timeShiftNanos);
+		LOGGER.trace("add {} {} to timeshift {} ns", delta, unit, timeShiftNanos);
 		timeShiftNanos += unit.toNanos(delta);
 	}
 
@@ -71,7 +71,7 @@ public class TestTimeRule extends TestWatcher {
 	 * @param unit unit of time shift
 	 */
 	public final synchronized void setTestTimeShift(final long shift, final TimeUnit unit) {
-		LOGGER.debug("set {} {} as timeshift", shift, unit);
+		LOGGER.trace("set {} {} as timeshift", shift, unit);
 		timeShiftNanos = unit.toNanos(shift);
 	}
 

--- a/element-connector/src/test/java/org/eclipse/californium/elements/rule/ThreadsRule.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/rule/ThreadsRule.java
@@ -182,13 +182,13 @@ public class ThreadsRule implements TestRule {
 	 * @param list list of threads
 	 */
 	public void dump(String message, List<Thread> list) {
-		LOGGER.info("Threads {}: {} threads", message, list.size());
+		LOGGER.trace("Threads {}: {} threads", message, list.size());
 		for (Thread thread : list) {
 			ThreadGroup threadGroup = thread.getThreadGroup();
 			if (threadGroup != null) {
-				LOGGER.info("Threads {} : {}-{}", description, thread.getName(), threadGroup.getName());
+				LOGGER.trace("Threads {} : {}-{}", description, thread.getName(), threadGroup.getName());
 			} else {
-				LOGGER.info("Threads {} : {}", description, thread.getName());
+				LOGGER.trace("Threads {} : {}", description, thread.getName());
 			}
 			if (LOGGER.isTraceEnabled()) {
 				StackTraceElement[] stackTrace = thread.getStackTrace();

--- a/element-connector/src/test/java/org/eclipse/californium/elements/runner/TestRepeater.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/runner/TestRepeater.java
@@ -110,7 +110,7 @@ public class TestRepeater {
 		if (0 == maximumRepeats) {
 			LOGGER.info("repeat until error!");
 		} else {
-			LOGGER.info("maximum repeats: {}", maximumRepeats);
+			LOGGER.debug("maximum repeats: {}", maximumRepeats);
 		}
 		// start alive logging
 		Thread alive = startAliveLogging();

--- a/element-connector/src/test/java/org/eclipse/californium/elements/util/DirectDatagramSocketImpl.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/util/DirectDatagramSocketImpl.java
@@ -628,7 +628,7 @@ public class DirectDatagramSocketImpl extends AbstractDatagramSocketImpl {
 		String message;
 		while ((message = logBuffer.poll()) != null) {
 			++counter;
-			LOGGER.info(String.format("--%02d--> %s", counter, message));
+			LOGGER.trace(String.format("--%02d--> %s", counter, message));
 		}
 	}
 

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/DTLSConnector.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/DTLSConnector.java
@@ -1446,7 +1446,7 @@ public class DTLSConnector implements Connector, RecordLayer {
 		} else {
 			// change cipher spec can only be processed within the
 			// context of an existing handshake -> ignore record
-			LOGGER.debug("Received CHANGE_CIPHER_SPEC record from peer [{}] with no handshake going on", record.getPeerAddress());
+			LOGGER.trace("Received CHANGE_CIPHER_SPEC record from peer [{}] with no handshake going on", record.getPeerAddress());
 		}
 	}
 

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/DtlsHealthLogger.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/DtlsHealthLogger.java
@@ -67,7 +67,7 @@ public class DtlsHealthLogger implements DtlsHealth {
 				log.append(head).append(droppedSentRecords).append(eol);
 				log.append(head).append(receivedRecords).append(eol);
 				log.append(head).append(droppedReceivedRecords);
-				LOGGER.debug("{}", log);
+				LOGGER.trace("{}", log);
 			}
 		} catch (Throwable e) {
 			LOGGER.error("{}", tag, e);

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/CertificateMessage.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/CertificateMessage.java
@@ -276,7 +276,7 @@ public final class CertificateMessage extends HandshakeMessage {
 			InetSocketAddress peerAddress) throws HandshakeException {
 
 		if (CertificateType.RAW_PUBLIC_KEY == certificateType) {
-			LOGGER.debug("Parsing RawPublicKey CERTIFICATE message");
+			LOGGER.trace("Parsing RawPublicKey CERTIFICATE message");
 			int certificateLength = reader.read(CERTIFICATE_LENGTH_BITS);
 			byte[] rawPublicKey = reader.readBytes(certificateLength);
 			return new CertificateMessage(rawPublicKey, peerAddress);

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/CertificateRequest.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/CertificateRequest.java
@@ -509,7 +509,7 @@ public final class CertificateRequest extends HandshakeMessage {
 				return false;
 			}
 		}
-		LOGGER.debug("certificate chain is signed with supported algorithm(s)");
+		LOGGER.trace("certificate chain is signed with supported algorithm(s)");
 		return true;
 	}
 
@@ -530,7 +530,7 @@ public final class CertificateRequest extends HandshakeMessage {
 				return true;
 			}
 		}
-		LOGGER.debug("certificate is NOT signed with supported algorithm(s)");
+		LOGGER.trace("certificate is NOT signed with supported algorithm(s)");
 		return false;
 	}
 

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ClientHandshaker.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ClientHandshaker.java
@@ -671,7 +671,7 @@ public class ClientHandshaker extends Handshaker {
 		if (maxFragmentLengthCode != null) {
 			MaxFragmentLengthExtension ext = new MaxFragmentLengthExtension(maxFragmentLengthCode); 
 			helloMessage.addExtension(ext);
-			LOGGER.debug(
+			LOGGER.trace(
 					"Indicating max. fragment length [{}] to server [{}]",
 					maxFragmentLengthCode, getPeerAddress());
 		}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/CompressionMethod.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/CompressionMethod.java
@@ -74,7 +74,7 @@ public enum CompressionMethod {
 			return CompressionMethod.DEFLATE;
 
 		default:
-			LOGGER.debug("Unknown compression method code: {}", code);
+			LOGGER.trace("Unknown compression method code: {}", code);
 			return null;
 		}
 	}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/DebugConnectionStore.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/DebugConnectionStore.java
@@ -66,7 +66,7 @@ public final class DebugConnectionStore extends InMemoryConnectionStore {
 		} else {
 			Connection connection = get(address);
 			if (connection == null) {
-				LOG.info("  {}connection: {} - not available!", tag, address);
+				LOG.trace("  {}connection: {} - not available!", tag, address);
 			} else {
 				dump(connection);
 				return true;
@@ -80,10 +80,10 @@ public final class DebugConnectionStore extends InMemoryConnectionStore {
 	 */
 	private void dump(Connection connection) {
 		if (connection.hasEstablishedSession()) {
-			LOG.info("  {}connection: {} - {} : {}", tag, connection.getConnectionId(),
+			LOG.trace("  {}connection: {} - {} : {}", tag, connection.getConnectionId(),
 					connection.getPeerAddress(), connection.getEstablishedSession().getSessionIdentifier());
 		} else {
-			LOG.info("  {}connection: {} - {}", tag, connection.getConnectionId(), connection.getPeerAddress());
+			LOG.trace("  {}connection: {} - {}", tag, connection.getConnectionId(), connection.getPeerAddress());
 		}
 	}
 
@@ -147,7 +147,7 @@ public final class DebugConnectionStore extends InMemoryConnectionStore {
 	private <K> void dump(ConcurrentMap<K, Connection> map) {
 		for (K key : map.keySet()) {
 			Connection connection = map.get(key);
-			LOG.warn("  {} connection: {} - {}", tag, key, connection);
+			LOG.trace("  {} connection: {} - {}", tag, key, connection);
 		}
 	}
 }

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ECDHServerKeyExchange.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ECDHServerKeyExchange.java
@@ -200,7 +200,7 @@ public final class ECDHServerKeyExchange extends ServerKeyExchange {
 			break;
 
 		default:
-			LOGGER.warn(MSG_UNKNOWN_CURVE_TYPE, curveType);
+			LOGGER.trace(MSG_UNKNOWN_CURVE_TYPE, curveType);
 			break;
 		}
 
@@ -278,7 +278,7 @@ public final class ECDHServerKeyExchange extends ServerKeyExchange {
 			break;
 
 		default:
-			LOGGER.warn(MSG_UNKNOWN_CURVE_TYPE, curveType);
+			LOGGER.trace(MSG_UNKNOWN_CURVE_TYPE, curveType);
 			break;
 		}
 		

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Finished.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Finished.java
@@ -119,7 +119,7 @@ public final class Finished extends HandshakeMessage {
 				msg.append(StringUtil.lineSeparator()).append("Expected: ").append(StringUtil.byteArray2HexString(myVerifyData));
 				msg.append(StringUtil.lineSeparator()).append("Received: ").append(StringUtil.byteArray2HexString(verifyData));
 			}
-			LOG.debug(msg.toString());
+			LOG.trace(msg.toString());
 			AlertMessage alert = new AlertMessage(AlertLevel.FATAL, AlertDescription.HANDSHAKE_FAILURE, getPeer());
 			throw new HandshakeException("Verification of FINISHED message failed", alert);
 		}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Handshaker.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Handshaker.java
@@ -429,7 +429,7 @@ public abstract class Handshaker implements Destroyable {
 						return null;
 					}
 				default:
-					LOGGER.warn("Cannot process message of type [{}], discarding...", fragment.getContentType());
+					LOGGER.info("Cannot process message of type [{}], discarding...", fragment.getContentType());
 					return null;
 				}
 			} else {
@@ -1081,7 +1081,7 @@ public abstract class Handshaker implements Destroyable {
 			deferredRecordsSize += size;
 			return true;
 		} else {
-			LOGGER.debug("Dropped incoming record from peer [{}], limit of {} bytes exceeded by {}+{} bytes!",
+			LOGGER.trace("Dropped incoming record from peer [{}], limit of {} bytes exceeded by {}+{} bytes!",
 					incomingMessage.getPeerAddress(), maxDeferredProcessedIncomingRecordsSize, deferredRecordsSize, size);
 			return false;
 		}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/InMemoryConnectionStore.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/InMemoryConnectionStore.java
@@ -456,7 +456,7 @@ public class InMemoryConnectionStore implements ResumptionSupportingConnectionSt
 	@Override
 	public synchronized int remainingCapacity() {
 		int remaining = connections.remainingCapacity();
-		LOG.debug("{}connection: size {}, remaining {}!", tag, connections.size(), remaining);
+		LOG.trace("{}connection: size {}, remaining {}!", tag, connections.size(), remaining);
 		return remaining;
 	}
 

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/ReassemblingHandshakeMessageTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/ReassemblingHandshakeMessageTest.java
@@ -96,7 +96,7 @@ public class ReassemblingHandshakeMessageTest {
 	}
 
 	private void log(FragmentedHandshakeMessage msg) {
-		LOGGER.info(" fragment [{}:{})", msg.getFragmentOffset(), msg.getFragmentOffset() + msg.getFragmentLength());
+		LOGGER.trace(" fragment [{}:{})", msg.getFragmentOffset(), msg.getFragmentOffset() + msg.getFragmentLength());
 	}
 
 	private void log() {
@@ -107,9 +107,9 @@ public class ReassemblingHandshakeMessageTest {
 
 	private void log(ReassemblingHandshakeMessage reassembledMessage) {
 		List<Object> ranges = reassembledMessage.getRanges();
-		LOGGER.info("{} ranges", ranges.size());
+		LOGGER.trace("{} ranges", ranges.size());
 		for (Object range : ranges) {
-			LOGGER.info("  {}", range);
+			LOGGER.trace("  {}", range);
 		}
 	}
 


### PR DESCRIPTION
We appreciate your previous feedback and it's very helpful! Here's a reissue of californium7170 with a new version of our tool.  Again, we'd appreciate any feedback and are willing to make further changes if you wish to incorporate our PR into your project.

Settings
---
We have several analysis settings. We can vary these settings and rerun if you desire. The settings we are using in this pull request are:

- Treat CONFIG/WARNING/SEVERE levels as a category and not a traditional level, i.e., our tool ignores these log levels.
- Never lower the logging level of logging statements within catch blocks.
- Never lower the logging level of logging statements within if statements.
- Never lower the logging level of logging statements containing certain (important) keywords.
- Never raise the logging level of logging statements without particular keywords in their messages.
- Avoid log wrapping by disregarding logging statements contained in if statements mentioning log levels.

The greatest number of commits from HEAD evaluated: 1000.
The head at the time of analysis was: 785267fc8a2486260e1e65144ebaf6ca1c1ac81b


- [x] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/selenium/blob/master/CONTRIBUTING.md#step-6-sign-the-cla)

