### PR TITLE
Rejuvenate log levels (options off)

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/CoapResource.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/CoapResource.java
@@ -767,7 +767,7 @@ public  class CoapResource implements Resource {
 	@Override
 	public void removeObserveRelation(ObserveRelation relation) {
 		if (observeRelations.remove(relation)) {
-			LOGGER.info("remove observe relation between {} and resource {} ({}, size {})", relation.getKey(), getURI(),
+			LOGGER.trace("remove observe relation between {} and resource {} ({}, size {})", relation.getKey(), getURI(),
 					relation.getExchange(), observeRelations.getSize());
 			for (ResourceObserver obs : observers) {
 				obs.removedObserveRelation(relation);

--- a/californium-core/src/main/java/org/eclipse/californium/core/CoapServer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/CoapServer.java
@@ -272,7 +272,7 @@ public class CoapServer implements ServerInterface {
 	public synchronized void stop() {
 
 		if (running) {
-			LOGGER.info("Stopping server");
+			LOGGER.trace("Stopping server");
 			for (Endpoint ep : endpoints) {
 				ep.stop();
 			}

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/CoapEndpointHealthLogger.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/CoapEndpointHealthLogger.java
@@ -64,7 +64,7 @@ public class CoapEndpointHealthLogger implements CoapEndpointHealth {
 				log.append(head).append(receivedRejects).append(eol);
 				log.append(head).append(duplicateRequests).append(eol);
 				log.append(head).append(duplicateResponses);
-				LOGGER.debug("{}", log);
+				LOGGER.trace("{}", log);
 			}
 		} catch (Throwable e) {
 			LOGGER.error("{}", tag, e);

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/RandomTokenGenerator.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/RandomTokenGenerator.java
@@ -63,7 +63,7 @@ public class RandomTokenGenerator implements TokenGenerator {
 		// trigger self-seeding of the PRNG, may "take a while"
 		this.rng.nextInt(10);
 		this.tokenSize = networkConfig.getInt(Keys.TOKEN_SIZE_LIMIT, DEFAULT_TOKEN_LENGTH);
-		LOGGER.info("using tokens of {} bytes in length", this.tokenSize);
+		LOGGER.trace("using tokens of {} bytes in length", this.tokenSize);
 	}
 
 	@Override

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/config/NetworkConfig.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/config/NetworkConfig.java
@@ -314,7 +314,7 @@ public final class NetworkConfig {
 	 * @return the configuration
 	 */
 	public static NetworkConfig createStandardWithoutFile() {
-		LOGGER.info("Creating standard network configuration properties without a file");
+		LOGGER.trace("Creating standard network configuration properties without a file");
 		return standard = new NetworkConfig();
 	}
 

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BlockwiseLayer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BlockwiseLayer.java
@@ -828,24 +828,24 @@ public class BlockwiseLayer extends AbstractLayer {
 			// ongoing blockwise transfer
 			if (starting) {
 				if (status.isNew(response)) {
-					LOGGER.debug("discarding outdated block2 transfer {}, current is [{}]", status.getObserve(),
+					LOGGER.trace("discarding outdated block2 transfer {}, current is [{}]", status.getObserve(),
 							response);
 					clearBlock2Status(key, status);
 					status.completeOldTransfer(exchange);
 				} else {
-					LOGGER.debug("discarding old block2 transfer [{}], received during ongoing block2 transfer {}",
+					LOGGER.trace("discarding old block2 transfer [{}], received during ongoing block2 transfer {}",
 							response, status.getObserve());
 					status.completeNewTranfer(exchange);
 					return true;
 				}
 			} else if (!status.matchTransfer(exchange)) {
-				LOGGER.debug("discarding outdate block2 response [{}, {}] received during ongoing block2 transfer {}",
+				LOGGER.trace("discarding outdate block2 response [{}, {}] received during ongoing block2 transfer {}",
 						exchange.getNotificationNumber(), response, status.getObserve());
 				status.completeNewTranfer(exchange);
 				return true;
 			}
 		} else if (block != null && block.getNum() != 0) {
-			LOGGER.debug("discarding stale block2 response [{}, {}] received without ongoing block2 transfer for {}",
+			LOGGER.trace("discarding stale block2 response [{}, {}] received without ongoing block2 transfer for {}",
 					exchange.getNotificationNumber(), response, key);
 			exchange.setComplete();
 			return true;
@@ -1147,10 +1147,10 @@ public class BlockwiseLayer extends AbstractLayer {
 			newStatus = getOutboundBlock2Status(key, exchange, response);
 		}
 		if (previousStatus != null && !previousStatus.isComplete()) {
-			LOGGER.debug("stop previous block transfer {} {} for new {}", key, previousStatus, response);
+			LOGGER.trace("stop previous block transfer {} {} for new {}", key, previousStatus, response);
 			previousStatus.completeResponse();
 		} else {
-			LOGGER.debug("block transfer {} for {}", key, response);
+			LOGGER.trace("block transfer {} for {}", key, response);
 		}
 		return newStatus;
 	}

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/CoapUdpStack.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/CoapUdpStack.java
@@ -113,7 +113,7 @@ public class CoapUdpStack extends BaseCoapStack {
 		ReliabilityLayer reliabilityLayer;
 		if (config.getBoolean(NetworkConfig.Keys.USE_CONGESTION_CONTROL) == true) {
 			reliabilityLayer = CongestionControlLayer.newImplementation(config);
-			LOGGER.info("Enabling congestion control: {}", reliabilityLayer.getClass().getSimpleName());
+			LOGGER.debug("Enabling congestion control: {}", reliabilityLayer.getClass().getSimpleName());
 		} else {
 			reliabilityLayer = new ReliabilityLayer(config);
 		}

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/CongestionControlLayer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/CongestionControlLayer.java
@@ -482,7 +482,7 @@ public abstract class CongestionControlLayer extends ReliabilityLayer {
 		case "PeakhopperRto":
 			return new PeakhopperRto(config);
 		default:
-			LOGGER.info(
+			LOGGER.trace(
 				"configuration contains unsupported {}, using Cocoa",
 				NetworkConfig.Keys.CONGESTION_CONTROL_ALGORITHM);
 			return new Cocoa(config);

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/ObserveLayer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/ObserveLayer.java
@@ -141,7 +141,7 @@ public class ObserveLayer extends AbstractLayer {
 
 		if (response.isNotification() && exchange.getRequest().isCanceled()) {
 			// The request was canceled and we no longer want notifications
-			LOGGER.debug("rejecting notification for canceled Exchange");
+			LOGGER.trace("rejecting notification for canceled Exchange");
 			EmptyMessage rst = EmptyMessage.newRST(response);
 			sendEmptyMessage(exchange, rst);
 			// Matcher sets exchange as complete when RST is sent

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/TcpAdaptionLayer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/TcpAdaptionLayer.java
@@ -59,7 +59,7 @@ public class TcpAdaptionLayer extends AbstractLayer {
 	@Override
 	public void receiveEmptyMessage(Exchange exchange, EmptyMessage message) {
 		// Empty messages are ignored when running over TCP connector.
-		LOGGER.info("discarding empty message received in TCP mode: {}", message);
+		LOGGER.trace("discarding empty message received in TCP mode: {}", message);
 	}
 
 }

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/TcpObserveLayer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/TcpObserveLayer.java
@@ -71,7 +71,7 @@ public class TcpObserveLayer extends AbstractLayer {
 	public void receiveResponse(final Exchange exchange, final Response response) {
 		if (response.getOptions().hasObserve() && exchange.getRequest().isCanceled()) {
 			// The request was canceled and we no longer want notifications
-			LOGGER.debug("ignoring notification for canceled TCP Exchange");
+			LOGGER.trace("ignoring notification for canceled TCP Exchange");
 		} else {
 			// No observe option in response => always deliver
 			upper().receiveResponse(exchange, response);

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/CountingCoapHandler.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/CountingCoapHandler.java
@@ -74,7 +74,7 @@ public class CountingCoapHandler implements CoapHandler {
 			}
 			notifyAll();
 		}
-		LOGGER.info("Received {}. Notification: {}", counter, response.advanced());
+		LOGGER.trace("Received {}. Notification: {}", counter, response.advanced());
 	}
 
 	/**
@@ -95,7 +95,7 @@ public class CountingCoapHandler implements CoapHandler {
 			counter = errorCalls.incrementAndGet();
 			notifyAll();
 		}
-		LOGGER.info("{} Errors!", counter);
+		LOGGER.trace("{} Errors!", counter);
 	}
 
 	public int getOnLoadCalls() {

--- a/californium-osgi/src/main/java/org/eclipse/californium/osgi/ManagedServer.java
+++ b/californium-osgi/src/main/java/org/eclipse/californium/osgi/ManagedServer.java
@@ -193,7 +193,7 @@ public class ManagedServer implements ManagedService, ServiceTrackerCustomizer<R
 	 */
 	public void stop() {
 		if (managedServer != null) {
-			LOGGER.debug("Destroying managed server instance");
+			LOGGER.trace("Destroying managed server instance");
 			if (resourceTracker != null) {
 				// stop tracking Resources
 				resourceTracker.close();
@@ -216,7 +216,7 @@ public class ManagedServer implements ManagedService, ServiceTrackerCustomizer<R
 	@Override
 	public Resource addingService(ServiceReference<Resource> reference) {
 		Resource resource = context.getService(reference);
-		LOGGER.debug("Adding resource [{}]", resource.getName());
+		LOGGER.trace("Adding resource [{}]", resource.getName());
 		if (resource != null) {
 			managedServer.add(resource);
 		}
@@ -235,7 +235,7 @@ public class ManagedServer implements ManagedService, ServiceTrackerCustomizer<R
 	@Override
 	public void removedService(ServiceReference<Resource> reference,
 			Resource service) {
-		LOGGER.debug("Removing resource [{}]", service.getName());
+		LOGGER.trace("Removing resource [{}]", service.getName());
 		managedServer.remove(service);
 		context.ungetService(reference);
 	}

--- a/californium-proxy/src/main/java/org/eclipse/californium/proxy/CoapTranslator.java
+++ b/californium-proxy/src/main/java/org/eclipse/californium/proxy/CoapTranslator.java
@@ -128,7 +128,7 @@ public final class CoapTranslator {
 			outgoingRequest.setURI(serverUri);
 		}
 
-		LOGGER.debug("Incoming request translated correctly");
+		LOGGER.trace("Incoming request translated correctly");
 		return outgoingRequest;
 	}
 	
@@ -166,7 +166,7 @@ public final class CoapTranslator {
 		outgoingResponse.setOptions(new OptionSet(
 				incomingResponse.getOptions()));
 		
-		LOGGER.debug("Incoming response translated correctly");
+		LOGGER.trace("Incoming response translated correctly");
 		return outgoingResponse;
 	}
 

--- a/californium-proxy/src/main/java/org/eclipse/californium/proxy/DirectProxyCoapResolver.java
+++ b/californium-proxy/src/main/java/org/eclipse/californium/proxy/DirectProxyCoapResolver.java
@@ -47,7 +47,7 @@ public class DirectProxyCoapResolver implements ProxyCoapResolver {
 
 	@Override
 	public void forwardRequest(Exchange exchange) {
-		LOGGER.debug("Forward CoAP request to ProxyCoap2Coap: {}", exchange.getRequest());
+		LOGGER.trace("Forward CoAP request to ProxyCoap2Coap: {}", exchange.getRequest());
 		proxyCoapClientResource.handleRequest(exchange);
 	}
 }

--- a/californium-proxy/src/main/java/org/eclipse/californium/proxy/HttpRequestContext.java
+++ b/californium-proxy/src/main/java/org/eclipse/californium/proxy/HttpRequestContext.java
@@ -64,7 +64,7 @@ public final class HttpRequestContext {
 			// translate the coap response in an http response
 			new HttpTranslator().getHttpResponse(httpRequest, coapResponse, httpResponse);
 
-			LOGGER.debug("Outgoing http response: {}", httpResponse.getStatusLine());
+			LOGGER.trace("Outgoing http response: {}", httpResponse.getStatusLine());
 		} catch (TranslationException e) {
 			LOGGER.warn("Failed to translate coap response to http response: {}", e.getMessage());
 			sendSimpleHttpResponse(HttpTranslator.STATUS_TRANSLATION_ERROR);

--- a/californium-proxy/src/main/java/org/eclipse/californium/proxy/HttpStack.java
+++ b/californium-proxy/src/main/java/org/eclipse/californium/proxy/HttpStack.java
@@ -191,7 +191,7 @@ public class HttpStack {
 				// Create server-side I/O reactor
 				ioReactor = new DefaultListeningIOReactor();
 				// Listen of the given port
-				LOGGER.info("HttpStack listening on port {}", httpPort);
+				LOGGER.debug("HttpStack listening on port {}", httpPort);
 				ioReactor.listen(new InetSocketAddress(httpPort));
 
 				// create the listener thread
@@ -202,20 +202,20 @@ public class HttpStack {
 						// Starts the reactor and initiates the dispatch of I/O
 						// event notifications to the given IOEventDispatch.
 						try {
-							LOGGER.info("Submitted http listening to thread 'HttpStack listener'");
+							LOGGER.debug("Submitted http listening to thread 'HttpStack listener'");
 
 							ioReactor.execute(ioEventDispatch);
 						} catch (IOException e) {
 							LOGGER.error("I/O Exception in HttpStack", e);
 						}
 
-						LOGGER.info("Shutdown HttpStack");
+						LOGGER.debug("Shutdown HttpStack");
 					}
 				};
 
 				listener.setDaemon(false);
 				listener.start();
-				LOGGER.info("HttpStack started");
+				LOGGER.debug("HttpStack started");
 			} catch (IOException e) {
 				LOGGER.error("I/O error", e);
 			}
@@ -240,7 +240,7 @@ public class HttpStack {
 				httpResponse.setEntity(new StringEntity("Californium Proxy server"));
 
 //				if (Bench_Help.DO_LOG) 
-					LOGGER.debug("Root request handled");
+					LOGGER.trace("Root request handled");
 			}
 		}
 
@@ -288,7 +288,7 @@ public class HttpStack {
 					// translate the request in a valid coap request
 					Request coapRequest = new HttpTranslator().getCoapRequest(httpRequest, localResource, proxyingEnabled);
 //					if (Bench_Help.DO_LOG) 
-						LOGGER.info("Received HTTP request and translate to {}", coapRequest);
+						LOGGER.debug("Received HTTP request and translate to {}", coapRequest);
 
 					// handle the requset
 					requestHandler.handleRequest(coapRequest, httpRequestContext);

--- a/californium-proxy/src/main/java/org/eclipse/californium/proxy/HttpTranslator.java
+++ b/californium-proxy/src/main/java/org/eclipse/californium/proxy/HttpTranslator.java
@@ -664,7 +664,7 @@ public final class HttpTranslator {
 				try {
 					contentType = ContentType.parse(coapContentTypeString);
 				} catch (UnsupportedCharsetException e) {
-					LOGGER.debug("Cannot convert string to ContentType", e);
+					LOGGER.trace("Cannot convert string to ContentType", e);
 					contentType = ContentType.APPLICATION_OCTET_STREAM;
 				}
 			}
@@ -920,7 +920,7 @@ public final class HttpTranslator {
 			if (coapResponse.getOptions().getContentFormat() == MediaTypeRegistry.UNDEFINED
 					&& (ResponseCode.isClientError(coapCode) 
 					|| ResponseCode.isServerError(coapCode))) {
-				LOGGER.info("Set contenttype to TEXT_PLAIN");
+				LOGGER.trace("Set contenttype to TEXT_PLAIN");
 				coapResponse.getOptions().setContentFormat(MediaTypeRegistry.TEXT_PLAIN);
 			}
 
@@ -971,7 +971,7 @@ public final class HttpTranslator {
 			// If the character sequence starting at the input buffer's current
 			// position cannot be mapped to an equivalent byte sequence and the
 			// current unmappable-character
-			LOGGER.debug("Charset translation: cannot mapped to an output char byte", e);
+			LOGGER.trace("Charset translation: cannot mapped to an output char byte", e);
 			return null;
 		} catch (CharacterCodingException e) {
 			LOGGER.warn("Problem in the decoding/encoding charset", e);

--- a/californium-proxy/src/main/java/org/eclipse/californium/proxy/ProxyHttpServer.java
+++ b/californium-proxy/src/main/java/org/eclipse/californium/proxy/ProxyHttpServer.java
@@ -106,7 +106,7 @@ public class ProxyHttpServer {
 				request.setResponse(response);
 				responseProduced(request, response);
 				context.handleRequestForwarding(response);
-				LOGGER.info("HTTP returned {}", response);
+				LOGGER.trace("HTTP returned {}", response);
 			}
 		};
 		exchange.setRequest(request);
@@ -184,7 +184,7 @@ public class ProxyHttpServer {
 			clientPath = PROXY_COAP_CLIENT;
 		}
 
-		LOGGER.info("Chose {} as clientPath", clientPath);
+		LOGGER.trace("Chose {} as clientPath", clientPath);
 
 		// set the path in the request to be forwarded correctly
 		request.getOptions().setUriPath(clientPath);

--- a/californium-proxy/src/main/java/org/eclipse/californium/proxy/resources/ProxyCacheResource.java
+++ b/californium-proxy/src/main/java/org/eclipse/californium/proxy/resources/ProxyCacheResource.java
@@ -236,7 +236,7 @@ public class ProxyCacheResource extends CoapResource implements CacheResource {
 
 		// if the response is not null, manage the cached response
 		if (response != null) {
-			LOGGER.debug("Cache hit");
+			LOGGER.trace("Cache hit");
 
 			// check if the response is expired
 			long currentTime = ClockUtil.nanoRealtime();
@@ -248,12 +248,12 @@ public class ProxyCacheResource extends CoapResource implements CacheResource {
 				// set the current time as the response timestamp
 				response.setNanoTimestamp(currentTime);
 			} else {
-				LOGGER.debug("Expired response");
+				LOGGER.trace("Expired response");
 
 				// try to validate the response
 				response = validate(cacheKey);
 				if (response != null) {
-					LOGGER.debug("Validation successful");
+					LOGGER.trace("Validation successful");
 				} else {
 					invalidateRequest(cacheKey);
 				}
@@ -266,7 +266,7 @@ public class ProxyCacheResource extends CoapResource implements CacheResource {
 	@Override
 	public void invalidateRequest(Request request) {
 		invalidateRequest(CacheKey.fromAcceptOptions(request));
-		LOGGER.debug("Invalidated request");
+		LOGGER.trace("Invalidated request");
 	}
 
 	@Override

--- a/californium-proxy/src/main/java/org/eclipse/californium/proxy/resources/ProxyCoapClientResource.java
+++ b/californium-proxy/src/main/java/org/eclipse/californium/proxy/resources/ProxyCoapClientResource.java
@@ -80,7 +80,7 @@ public class ProxyCoapClientResource extends ForwardingResource {
 
 				@Override
 				public void onResponse(Response incomingResponse) {
-					LOGGER.debug("ProxyCoapClientResource received {}", incomingResponse);
+					LOGGER.trace("ProxyCoapClientResource received {}", incomingResponse);
 					future.complete(CoapTranslator.getResponse(incomingResponse));
 					EndPointManagerPool.putClient(endpointManager);
 				}
@@ -119,7 +119,7 @@ public class ProxyCoapClientResource extends ForwardingResource {
 			});
 
 			// execute the request
-			LOGGER.debug("Sending proxied CoAP request.");
+			LOGGER.info("Sending proxied CoAP request.");
 
 			if (outgoingRequest.getDestination() == null) {
 				throw new NullPointerException("Destination is null");

--- a/californium-proxy/src/main/java/org/eclipse/californium/proxy/resources/ProxyHttpClientResource.java
+++ b/californium-proxy/src/main/java/org/eclipse/californium/proxy/resources/ProxyHttpClientResource.java
@@ -118,7 +118,7 @@ public class ProxyHttpClientResource extends ForwardingResource {
 			@Override
 			public void completed(HttpResponse result) {
 				long timestamp = ClockUtil.nanoRealtime();
-				LOGGER.debug("Incoming http response: {}", result.getStatusLine());
+				LOGGER.trace("Incoming http response: {}", result.getStatusLine());
 				// the entity of the response, if non repeatable, could be
 				// consumed only one time, so do not debug it!
 				// System.out.println(EntityUtils.toString(httpResponse.getEntity()));

--- a/cf-oscore/src/main/java/org/eclipse/californium/oscore/ContextRederivation.java
+++ b/cf-oscore/src/main/java/org/eclipse/californium/oscore/ContextRederivation.java
@@ -423,9 +423,9 @@ public class ContextRederivation {
 
 		String output = "Context re-derivation phase: " + currentPhase + " (" + supplemental + ")";
 		if (currentPhase == PHASE.INACTIVE) {
-			LOGGER.debug(output);
+			LOGGER.trace(output);
 		} else {
-			LOGGER.info(output);
+			LOGGER.trace(output);
 		}
 	}
 

--- a/cf-oscore/src/main/java/org/eclipse/californium/oscore/OSCoreStack.java
+++ b/cf-oscore/src/main/java/org/eclipse/californium/oscore/OSCoreStack.java
@@ -54,7 +54,7 @@ public class OSCoreStack extends BaseCoapStack {
 		ReliabilityLayer reliabilityLayer;
 		if (config.getBoolean(NetworkConfig.Keys.USE_CONGESTION_CONTROL)) {
 			reliabilityLayer = CongestionControlLayer.newImplementation(config);
-			LOGGER.info("Enabling congestion control: {0}", reliabilityLayer.getClass().getSimpleName());
+			LOGGER.debug("Enabling congestion control: {0}", reliabilityLayer.getClass().getSimpleName());
 		} else {
 			reliabilityLayer = new ReliabilityLayer(config);
 		}

--- a/cf-oscore/src/main/java/org/eclipse/californium/oscore/ObjectSecurityContextLayer.java
+++ b/cf-oscore/src/main/java/org/eclipse/californium/oscore/ObjectSecurityContextLayer.java
@@ -141,7 +141,7 @@ public class ObjectSecurityContextLayer extends AbstractLayer {
 
 					});
 					// send start rederivation request
-					LOGGER.info("Auxiliary Request: " + exchange.getRequest().toString());
+					LOGGER.trace("Auxiliary Request: " + exchange.getRequest().toString());
 					final Exchange newExchange = new Exchange(startRederivation, Origin.LOCAL, executor);
 					newExchange.execute(new Runnable() {
 
@@ -161,7 +161,7 @@ public class ObjectSecurityContextLayer extends AbstractLayer {
 				return;
 			}
 		}
-		LOGGER.info("Request: " + exchange.getRequest().toString());
+		LOGGER.trace("Request: " + exchange.getRequest().toString());
 		super.sendRequest(exchange, request);
 	}
 

--- a/cf-oscore/src/main/java/org/eclipse/californium/oscore/RequestDecryptor.java
+++ b/cf-oscore/src/main/java/org/eclipse/californium/oscore/RequestDecryptor.java
@@ -63,7 +63,7 @@ public class RequestDecryptor extends Decryptor {
 	 */
 	public static Request decrypt(OSCoreCtxDB db, Request request) throws CoapOSException {
 		
-		LOGGER.info("Removes E options from outer options which are not allowed there");
+		LOGGER.debug("Removes E options from outer options which are not allowed there");
 		discardEOptions(request);
 
 		byte[] protectedData = request.getPayload();

--- a/cf-oscore/src/main/java/org/eclipse/californium/oscore/ResponseDecryptor.java
+++ b/cf-oscore/src/main/java/org/eclipse/californium/oscore/ResponseDecryptor.java
@@ -58,7 +58,7 @@ public class ResponseDecryptor extends Decryptor {
 	 */
 	public static Response decrypt(OSCoreCtxDB db, Response response) throws OSException {
 
-		LOGGER.info("Removes E options from outer options which are not allowed there");
+		LOGGER.debug("Removes E options from outer options which are not allowed there");
 		discardEOptions(response);
 
 		byte[] protectedData = response.getPayload();

--- a/demo-apps/cf-extplugtest-client/src/main/java/org/eclipse/californium/extplugtests/BenchmarkClient.java
+++ b/demo-apps/cf-extplugtest-client/src/main/java/org/eclipse/californium/extplugtests/BenchmarkClient.java
@@ -375,7 +375,7 @@ public class BenchmarkClient {
 					next();
 				}
 				long c = overallRequestsDownCounter.get();
-				LOGGER.info("Received response: {} {}", response.advanced(), c);
+				LOGGER.trace("Received response: {} {}", response.advanced(), c);
 			} else {
 				long c = requestsCounter.get();
 				LOGGER.warn("Received error response: {} {} ({} successful)", endpoint.getUri(), response.advanced(), c);
@@ -398,7 +398,7 @@ public class BenchmarkClient {
 				}
 				if (noneStop) {
 					transmissionErrorCounter.incrementAndGet();
-					LOGGER.info("Error after {} requests. {}", c, msg);
+					LOGGER.trace("Error after {} requests. {}", c, msg);
 					next();
 				} else {
 					LOGGER.error("failed after {} requests! {}", c, msg);
@@ -479,7 +479,7 @@ public class BenchmarkClient {
 			CoapResponse response = client.advanced(post);
 			if (response != null) {
 				if (response.isSuccess()) {
-					LOGGER.info("Received response: {}", response.advanced());
+					LOGGER.trace("Received response: {}", response.advanced());
 					clientCounter.incrementAndGet();
 					checkReady(true, true);
 					return true;
@@ -974,21 +974,21 @@ public class BenchmarkClient {
 		if (tag != null) {
 			// with tag, use file
 			logger = LoggerFactory.getLogger(logger.getName() + ".file");
-			logger.info("------- {} ------------------------------------------------", tag);
-			logger.info("{}, {}, {}", osMxBean.getName(), osMxBean.getVersion(), osMxBean.getArch());
+			logger.trace("------- {} ------------------------------------------------", tag);
+			logger.trace("{}, {}, {}", osMxBean.getName(), osMxBean.getVersion(), osMxBean.getArch());
 			StringBuilder line = new StringBuilder();
 			List<String> vmArgs = ManagementFactory.getRuntimeMXBean().getInputArguments();
 			for (String arg : vmArgs) {
 				line.append(arg).append(" ");
 			}
-			logger.info("{}", line);
+			logger.trace("{}", line);
 			line.setLength(0);
 			for (String arg : args) {
 				line.append(arg).append(" ");
 			}
-			logger.info("{}", line);
+			logger.trace("{}", line);
 		}
-		logger.info("uptime: {} ms, {} processors", TimeUnit.NANOSECONDS.toMillis(uptimeNanos), processors);
+		logger.trace("uptime: {} ms, {} processors", TimeUnit.NANOSECONDS.toMillis(uptimeNanos), processors);
 		ThreadMXBean threadMxBean = ManagementFactory.getThreadMXBean();
 		if (threadMxBean.isThreadCpuTimeSupported() && threadMxBean.isThreadCpuTimeEnabled()) {
 			long alltime = 0;
@@ -1000,7 +1000,7 @@ public class BenchmarkClient {
 				}
 			}
 			long pTime = alltime / processors;
-			logger.info("cpu-time: {} ms (per-processor: {} ms, load: {}%)",
+			logger.trace("cpu-time: {} ms (per-processor: {} ms, load: {}%)",
 					TimeUnit.NANOSECONDS.toMillis(alltime), TimeUnit.NANOSECONDS.toMillis(pTime),
 					(pTime * 100) / uptimeNanos);
 		}
@@ -1016,10 +1016,10 @@ public class BenchmarkClient {
 				gcTime += time;
 			}
 		}
-		logger.info("gc: {} ms, {} calls", gcTime, gcCount);
+		logger.trace("gc: {} ms, {} calls", gcTime, gcCount);
 		double loadAverage = osMxBean.getSystemLoadAverage();
 		if (!(loadAverage < 0.0d)) {
-			logger.info("average load: {}", String.format("%.2f", loadAverage));
+			logger.trace("average load: {}", String.format("%.2f", loadAverage));
 		}
 		return logger;
 	}

--- a/demo-apps/cf-extplugtest-client/src/main/java/org/eclipse/californium/extplugtests/resources/Feed.java
+++ b/demo-apps/cf-extplugtest-client/src/main/java/org/eclipse/californium/extplugtests/resources/Feed.java
@@ -215,18 +215,18 @@ public class Feed extends CoapResource {
 					if (timeout < DEFAULT_TIMEOUT_IN_MILLIS) {
 						timeout = DEFAULT_TIMEOUT_IN_MILLIS;
 					}
-					LOGGER.info("client[{}] {} observer, wait for response {} completed.", id, observer,
+					LOGGER.trace("client[{}] {} observer, wait for response {} completed.", id, observer,
 							response.getToken());
 				} else {
 					timeout = 0;
-					LOGGER.info("client[{}] next change in {} ms, {} observer.", id, interval, observer);
+					LOGGER.trace("client[{}] next change in {} ms, {} observer.", id, interval, observer);
 					executorService.schedule(change, interval, TimeUnit.MILLISECONDS);
 				}
 			} else {
-				LOGGER.info("client[{}] pending change, {} observer, send {}!", id, observer, response.getToken());
+				LOGGER.trace("client[{}] pending change, {} observer, send {}!", id, observer, response.getToken());
 			}
 		} else {
-			LOGGER.info("client[{}] no observe {}!", id, request);
+			LOGGER.trace("client[{}] no observe {}!", id, request);
 		}
 		response.addMessageObserver(new MessageCompletionObserver(timeout, interval));
 		exchange.respond(response);
@@ -275,7 +275,7 @@ public class Feed extends CoapResource {
 			// timeout
 			if (completed.compareAndSet(false, true)) {
 				if (interval < 0) {
-					LOGGER.info("client[{}] response didn't complete in time, next change in {} ms, {} observer.", id,
+					LOGGER.trace("client[{}] response didn't complete in time, next change in {} ms, {} observer.", id,
 							-interval, getObserverCount());
 					timeouts.incrementAndGet();
 					executorService.schedule(change, -interval, TimeUnit.MILLISECONDS);
@@ -289,11 +289,11 @@ public class Feed extends CoapResource {
 				timeoutJob.cancel(false);
 			}
 			if (interval < 0) {
-				LOGGER.info("client[{}] response {}, next change in {} ms, {} observer.", id, state, -interval,
+				LOGGER.trace("client[{}] response {}, next change in {} ms, {} observer.", id, state, -interval,
 						getObserverCount());
 				executorService.schedule(change, -interval, TimeUnit.MILLISECONDS);
 			} else {
-				LOGGER.info("client[{}] response {}, {} observer.", id, state, getObserverCount());
+				LOGGER.trace("client[{}] response {}, {} observer.", id, state, getObserverCount());
 			}
 		}
 	}

--- a/demo-apps/cf-extplugtest-server/src/main/java/org/eclipse/californium/extplugtests/ExtendedTestServer.java
+++ b/demo-apps/cf-extplugtest-server/src/main/java/org/eclipse/californium/extplugtests/ExtendedTestServer.java
@@ -231,7 +231,7 @@ public class ExtendedTestServer extends AbstractTestServer {
 		OperatingSystemMXBean osMxBean = ManagementFactory.getOperatingSystemMXBean();
 		int processors = osMxBean.getAvailableProcessors();
 		Logger logger = STATISTIC_LOGGER;
-		logger.info("{} processors", processors);
+		logger.trace("{} processors", processors);
 		ThreadMXBean threadMxBean = ManagementFactory.getThreadMXBean();
 		if (threadMxBean.isThreadCpuTimeSupported() && threadMxBean.isThreadCpuTimeEnabled()) {
 			long alltime = 0;
@@ -243,7 +243,7 @@ public class ExtendedTestServer extends AbstractTestServer {
 				}
 			}
 			long pTime = alltime / processors;
-			logger.info("cpu-time: {} ms (per-processor: {} ms)",
+			logger.trace("cpu-time: {} ms (per-processor: {} ms)",
 					TimeUnit.NANOSECONDS.toMillis(alltime), TimeUnit.NANOSECONDS.toMillis(pTime));
 		}
 		long gcCount = 0;
@@ -258,10 +258,10 @@ public class ExtendedTestServer extends AbstractTestServer {
 				gcTime += time;
 			}
 		}
-		logger.info("gc: {} ms, {} calls", gcTime, gcCount);
+		logger.trace("gc: {} ms, {} calls", gcTime, gcCount);
 		double loadAverage = osMxBean.getSystemLoadAverage();
 		if (!(loadAverage < 0.0d)) {
-			logger.info("average load: {}", String.format("%.2f", loadAverage));
+			logger.trace("average load: {}", String.format("%.2f", loadAverage));
 		}
 	}
 	

--- a/demo-apps/cf-extplugtest-server/src/main/java/org/eclipse/californium/extplugtests/resources/ReverseObserve.java
+++ b/demo-apps/cf-extplugtest-server/src/main/java/org/eclipse/californium/extplugtests/resources/ReverseObserve.java
@@ -151,8 +151,8 @@ public class ReverseObserve extends CoapResource implements NotificationListener
 				@Override
 				public void run() {
 					if (overallNotifies.get() > 0) {
-						HEALTH_LOGGER.debug("{} observes, {} by peers", observesByToken.size(), observesByPeer.size());
-						HEALTH_LOGGER.debug("{} notifies overall, {} observes overall", overallNotifies.get(),
+						HEALTH_LOGGER.trace("{} observes, {} by peers", observesByToken.size(), observesByPeer.size());
+						HEALTH_LOGGER.trace("{} notifies overall, {} observes overall", overallNotifies.get(),
 								overallObserves.get());
 					}
 				}
@@ -210,11 +210,11 @@ public class ReverseObserve extends CoapResource implements NotificationListener
 					overallObserves.incrementAndGet();
 				} else {
 					if (pendingObservation != null) {
-						LOGGER.info("Requested cancel observation {}", pendingObservation.getObservationToken());
+						LOGGER.trace("Requested cancel observation {}", pendingObservation.getObservationToken());
 						endpoint.cancelObservation(pendingObservation.getObservationToken());
 						exchange.respond(CHANGED);
 					} else {
-						LOGGER.info("Requested cancel not established observation for {}", key);
+						LOGGER.trace("Requested cancel not established observation for {}", key);
 						exchange.respond(CHANGED);
 					}
 				}
@@ -235,9 +235,9 @@ public class ReverseObserve extends CoapResource implements NotificationListener
 		} else {
 			String peer = peersByToken.get(token);
 			if (peer != null) {
-				LOGGER.info("Notification {} from old observe: {}", response, peer);
+				LOGGER.trace("Notification {} from old observe: {}", response, peer);
 			} else {
-				LOGGER.info("Notification {} from unkown observe", response);
+				LOGGER.trace("Notification {} from unkown observe", response);
 			}
 		}
 	}
@@ -385,7 +385,7 @@ public class ReverseObserve extends CoapResource implements NotificationListener
 		@Override
 		public void onResponse(final Response response) {
 			if (response.isError()) {
-				LOGGER.info("Observation response error: {}", response.getCode());
+				LOGGER.trace("Observation response error: {}", response.getCode());
 				remove(response.getCode());
 			} else if (response.isNotification()) {
 				if (registered.compareAndSet(false, true)) {
@@ -396,7 +396,7 @@ public class ReverseObserve extends CoapResource implements NotificationListener
 							new ObservationRequest(incomingExchange, token));
 					if (previous != null && !previous.getObservationToken().equals(Token.EMPTY)
 							&& !token.equals(previous.getObservationToken())) {
-						LOGGER.info("Cancel previous observation {}", token);
+						LOGGER.trace("Cancel previous observation {}", token);
 						endpoint.cancelObservation(previous.getObservationToken());
 					}
 					peersByToken.put(token, key);
@@ -404,7 +404,7 @@ public class ReverseObserve extends CoapResource implements NotificationListener
 					incomingExchange.respond(CONTENT, token.getBytes(), APPLICATION_OCTET_STREAM);
 				}
 			} else {
-				LOGGER.info("Observation {} not established!", outgoingObserveRequest.getToken());
+				LOGGER.trace("Observation {} not established!", outgoingObserveRequest.getToken());
 				remove(NOT_ACCEPTABLE);
 			}
 		}
@@ -421,7 +421,7 @@ public class ReverseObserve extends CoapResource implements NotificationListener
 		@Override
 		protected void failed() {
 			if (!failureLogged) {
-				LOGGER.debug("Observe request failed! {}", outgoingObserveRequest.getToken());
+				LOGGER.trace("Observe request failed! {}", outgoingObserveRequest.getToken());
 			}
 			remove(INTERNAL_SERVER_ERROR);
 		}
@@ -429,7 +429,7 @@ public class ReverseObserve extends CoapResource implements NotificationListener
 		private void remove(ResponseCode code) {
 			String key = incomingExchange.getPeerKey();
 			observesByPeer.remove(key);
-			LOGGER.info("Removed observation for {}", key);
+			LOGGER.trace("Removed observation for {}", key);
 			incomingExchange.respond(code);
 		}
 	}
@@ -496,11 +496,11 @@ public class ReverseObserve extends CoapResource implements NotificationListener
 
 		private void reregister() {
 			String key = incomingExchange.getPeerKey();
-			LOGGER.info("Cancel observation {} for {}", observationToken, key);
+			LOGGER.trace("Cancel observation {} for {}", observationToken, key);
 			incomingExchange.getEndpoint().cancelObservation(observationToken);
 			observesByPeer.remove(key);
 			observesByToken.remove(observationToken, this);
-			LOGGER.info("Restart observation for {}", key);
+			LOGGER.trace("Restart observation for {}", key);
 			processPOST(incomingExchange);
 		}
 	}

--- a/demo-apps/cf-extplugtest-server/src/main/java/org/eclipse/californium/extplugtests/resources/ReverseRequest.java
+++ b/demo-apps/cf-extplugtest-server/src/main/java/org/eclipse/californium/extplugtests/resources/ReverseRequest.java
@@ -128,7 +128,7 @@ public class ReverseRequest extends CoapResource {
 				@Override
 				public void run() {
 					if (overallRequests.get() > 0) {
-						HEALTH_LOGGER.debug("{} reverse-requests, {} sent, {} pending", overallRequests.get(),
+						HEALTH_LOGGER.trace("{} reverse-requests, {} sent, {} pending", overallRequests.get(),
 								overallSentRequests.get(), overallPendingRequests.get());
 					}
 				}
@@ -183,10 +183,10 @@ public class ReverseRequest extends CoapResource {
 			long overall = overallRequests.addAndGet(numberOfRequests);
 			overallPendingRequests.addAndGet(numberOfRequests);
 			if (overallSentRequests.getAndIncrement() == 0) {
-				LOGGER.info("start reverse requests!");
+				LOGGER.trace("start reverse requests!");
 			}
-			LOGGER.debug("{}", request);
-			LOGGER.info("{}/{}: {} reverse requests, {} overall.", request.getSourceContext().getPeerAddress(),
+			LOGGER.trace("{}", request);
+			LOGGER.trace("{}/{}: {} reverse requests, {} overall.", request.getSourceContext().getPeerAddress(),
 					resource, numberOfRequests, overall);
 			Endpoint endpoint = exchange.advanced().getEndpoint();
 			exchange.respond(CHANGED);
@@ -224,7 +224,7 @@ public class ReverseRequest extends CoapResource {
 		public void onResponse(final Response response) {
 			job.cancel(false);
 			if (response.isError()) {
-				LOGGER.info("error: {}, pending: {}", response.getCode(), count);
+				LOGGER.trace("error: {}, pending: {}", response.getCode(), count);
 				subtractPending(count);
 			} else {
 				--count;
@@ -258,14 +258,14 @@ public class ReverseRequest extends CoapResource {
 		protected void failed() {
 			job.cancel(false);
 			if (!failureLogged) {
-				LOGGER.debug("reverse get request failed! MID {}, pending: {}", outgoingRequest.getMID(), count);
+				LOGGER.trace("reverse get request failed! MID {}, pending: {}", outgoingRequest.getMID(), count);
 			}
 			subtractPending(count);
 		}
 
 		private void subtractPending(int count) {
 			if (overallPendingRequests.addAndGet(-count) <= 0) {
-				LOGGER.info("sent all requests, ready!");
+				LOGGER.trace("sent all requests, ready!");
 			}
 		}
 

--- a/demo-apps/cf-nat/src/main/java/org/eclipse/californium/examples/NatUtil.java
+++ b/demo-apps/cf-nat/src/main/java/org/eclipse/californium/examples/NatUtil.java
@@ -446,10 +446,10 @@ public class NatUtil implements Runnable {
 		NatEntry entry = new NatEntry(incoming);
 		NatEntry old = nats.put(incoming, entry);
 		if (null != old) {
-			LOGGER.info("changed NAT for {} from {} to {}.", incoming, old.getPort(), entry.getPort());
+			LOGGER.trace("changed NAT for {} from {} to {}.", incoming, old.getPort(), entry.getPort());
 			old.stop();
 		} else {
-			LOGGER.info("add NAT for {} to {}.", incoming, entry.getPort());
+			LOGGER.trace("add NAT for {} to {}.", incoming, entry.getPort());
 		}
 		return entry.getPort();
 	}
@@ -551,12 +551,12 @@ public class NatUtil implements Runnable {
 			if (forward != null || backward != null) {
 				forward = null;
 				backward = null;
-				LOGGER.info("NAT stops message dropping.");
+				LOGGER.trace("NAT stops message dropping.");
 			}
 		} else {
 			forward = new MessageDropping("request", percent);
 			backward = new MessageDropping("responses", percent);
-			LOGGER.info("NAT message dropping {}%.", percent);
+			LOGGER.trace("NAT message dropping {}%.", percent);
 		}
 	}
 
@@ -573,11 +573,11 @@ public class NatUtil implements Runnable {
 		if (percent == 0) {
 			if (forward != null) {
 				forward = null;
-				LOGGER.info("NAT stops forward message dropping.");
+				LOGGER.trace("NAT stops forward message dropping.");
 			}
 		} else {
 			forward = new MessageDropping("request", percent);
-			LOGGER.info("NAT forward message dropping {}%.", percent);
+			LOGGER.trace("NAT forward message dropping {}%.", percent);
 		}
 	}
 
@@ -594,11 +594,11 @@ public class NatUtil implements Runnable {
 		if (percent == 0) {
 			if (backward != null) {
 				backward = null;
-				LOGGER.info("NAT stops backward message dropping.");
+				LOGGER.trace("NAT stops backward message dropping.");
 			}
 		} else {
 			backward = new MessageDropping("response", percent);
-			LOGGER.info("NAT backward message dropping {}%.", percent);
+			LOGGER.trace("NAT backward message dropping {}%.", percent);
 		}
 	}
 
@@ -620,11 +620,11 @@ public class NatUtil implements Runnable {
 		if (percent == 0) {
 			if (reorder != null) {
 				reorder = null;
-				LOGGER.info("NAT stops message reordering.");
+				LOGGER.trace("NAT stops message reordering.");
 			}
 		} else {
 			reorder = new MessageReordering("reordering", percent, delayMillis, randomDelayMillis);
-			LOGGER.info("NAT message reordering {}%.", percent);
+			LOGGER.trace("NAT message reordering {}%.", percent);
 		}
 	}
 

--- a/demo-apps/cf-plugtest-checker/src/main/java/org/eclipse/californium/plugtests/LinkParser.java
+++ b/demo-apps/cf-plugtest-checker/src/main/java/org/eclipse/californium/plugtests/LinkParser.java
@@ -48,7 +48,7 @@ public class LinkParser {
 				if (path.startsWith("/")) {
 					path = path.substring(1);
 				}
-				LOG.debug("Parsing link resource: {}", path);
+				LOG.trace("Parsing link resource: {}", path);
 				Resource resource = new CoapResource(path);
 				for (String attrName : link.getAttributes().getAttributeKeySet()) {
 					for (String attrValue : link.getAttributes().getAttributeValues(attrName)) {

--- a/demo-apps/cf-plugtest-client/src/main/java/org/eclipse/californium/plugtests/ClientInitializer.java
+++ b/demo-apps/cf-plugtest-client/src/main/java/org/eclipse/californium/plugtests/ClientInitializer.java
@@ -152,7 +152,7 @@ public class ClientInitializer {
 		Arguments arguments = new Arguments(uri, id, secret, rpk, x509, ecdhe, ping, verbose, json, cbor, null, null, leftArgs);
 		CoapEndpoint coapEndpoint = createEndpoint(config, arguments, null, ephemeralPort);
 		coapEndpoint.start();
-		LOGGER.info("endpoint started at {}", coapEndpoint.getAddress());
+		LOGGER.trace("endpoint started at {}", coapEndpoint.getAddress());
 		EndpointManager.getEndpointManager().setDefaultEndpoint(coapEndpoint);
 
 		return arguments;

--- a/demo-apps/sc-dtls-example-client/src/main/java/org/eclipse/californium/scandium/examples/ExampleDTLSClient.java
+++ b/demo-apps/sc-dtls-example-client/src/main/java/org/eclipse/californium/scandium/examples/ExampleDTLSClient.java
@@ -101,7 +101,7 @@ public class ExampleDTLSClient {
 		messageCounter.countDown();
 		long c = messageCounter.getCount();
 		if (LOG.isInfoEnabled()) {
-			LOG.info("Received response: {} {}", new Object[] { new String(raw.getBytes()), c });
+			LOG.trace("Received response: {} {}", new Object[] { new String(raw.getBytes()), c });
 		}
 		if (0 < c) {
 			clientMessageCounter.incrementAndGet();
@@ -109,7 +109,7 @@ public class ExampleDTLSClient {
 				RawData data = RawData.outbound((payload + c + ".").getBytes(), raw.getEndpointContext(), null, false);
 				dtlsConnector.send(data);
 			} catch (IllegalStateException e) {
-				LOG.debug("send failed after {} messages", (c - 1), e);
+				LOG.trace("send failed after {} messages", (c - 1), e);
 			}
 		} else {
 			dtlsConnector.destroy();

--- a/demo-apps/sc-dtls-example-server/src/main/java/org/eclipse/californium/scandium/examples/ExampleDTLSServer.java
+++ b/demo-apps/sc-dtls-example-server/src/main/java/org/eclipse/californium/scandium/examples/ExampleDTLSServer.java
@@ -95,7 +95,7 @@ public class ExampleDTLSServer {
 		@Override
 		public void receiveData(final RawData raw) {
 			if (LOG.isInfoEnabled()) {
-				LOG.info("Received request: {}", new String(raw.getBytes()));
+				LOG.trace("Received request: {}", new String(raw.getBytes()));
 			}
 			RawData response = RawData.outbound("ACK".getBytes(),
 					raw.getEndpointContext(), null, false);

--- a/element-connector/src/main/java/org/eclipse/californium/elements/auth/X509CertPath.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/auth/X509CertPath.java
@@ -162,9 +162,9 @@ public class X509CertPath extends AbstractExtensiblePrincipal<X509CertPath> {
 					throw new IllegalArgumentException("Given certificate is not X.509! " + cert);
 				}
 				X509Certificate xcert = (X509Certificate) cert;
-				LOGGER.debug("Current Subject DN: {}", xcert.getSubjectX500Principal().getName());
+				LOGGER.info("Current Subject DN: {}", xcert.getSubjectX500Principal().getName());
 				if (issuer != null && !issuer.equals(xcert.getSubjectX500Principal())) {
-					LOGGER.debug("Actual Issuer DN: {}", xcert.getSubjectX500Principal().getName());
+					LOGGER.info("Actual Issuer DN: {}", xcert.getSubjectX500Principal().getName());
 					throw new IllegalArgumentException("Given certificates do not form a chain");
 				}
 				++index;
@@ -181,7 +181,7 @@ public class X509CertPath extends AbstractExtensiblePrincipal<X509CertPath> {
 					// not a self-signed certificate
 					certificates.add(xcert);
 					issuer = xcert.getIssuerX500Principal();
-					LOGGER.debug("Expected Issuer DN: {}", issuer.getName());
+					LOGGER.info("Expected Issuer DN: {}", issuer.getName());
 				}
 			}
 			return factory.generateCertPath(certificates);

--- a/element-connector/src/main/java/org/eclipse/californium/elements/util/ExecutorsUtil.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/util/ExecutorsUtil.java
@@ -45,7 +45,7 @@ public class ExecutorsUtil {
 
 		@Override
 		public void run() {
-			LOGGER.trace("warmup ...");
+			LOGGER.info("warmup ...");
 		}
 	};
 
@@ -223,7 +223,7 @@ public class ExecutorsUtil {
 				long size = getQueue().size();
 				long diff = Math.abs(lastSize - size);
 				if (diff > QUEUE_SIZE_DIFF && scheduleQueueSize.compareAndSet(lastSize, size)) {
-					LOGGER.debug("Job queue {}", size);
+					LOGGER.trace("Job queue {}", size);
 				}
 				directExecutor.execute(command);
 			}

--- a/element-connector/src/main/java/org/eclipse/californium/elements/util/PemReader.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/util/PemReader.java
@@ -53,7 +53,7 @@ public class PemReader {
 			Matcher matcher = BEGIN_PATTERN.matcher(line);
 			if (matcher.matches()) {
 				tag = matcher.group(1);
-				LOGGER.debug("Found Begin of {}", tag);
+				LOGGER.trace("Found Begin of {}", tag);
 				break;
 			}
 		}
@@ -70,7 +70,7 @@ public class PemReader {
 				String end = matcher.group(1);
 				if (end.equals(tag)) {
 					byte[] decode = Base64.decode(buffer.toString());
-					LOGGER.debug("Found End of {}", tag);
+					LOGGER.trace("Found End of {}", tag);
 					return decode;
 				} else {
 					LOGGER.warn("Found End of {}, but expected {}!", end, tag);

--- a/element-connector/src/test/java/org/eclipse/californium/elements/rule/NetworkRule.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/rule/NetworkRule.java
@@ -348,7 +348,7 @@ public class NetworkRule implements TestRule {
 	protected void initNetwork(boolean outerScope) {
 		if (Mode.DIRECT == usedMode) {
 			if (outerScope && !DirectDatagramSocketImpl.isEmpty()) {
-				LOGGER.info("Previous test didn't 'closeNetwork()'!");
+				LOGGER.debug("Previous test didn't 'closeNetwork()'!");
 				DirectDatagramSocketImpl.clearAll();
 			}
 			DirectDatagramSocketImpl.configure(formatter, delayInMillis);
@@ -367,7 +367,7 @@ public class NetworkRule implements TestRule {
 	protected void closeNetwork() {
 		if (Mode.DIRECT == usedMode) {
 			if (!DirectDatagramSocketImpl.isEmpty()) {
-				LOGGER.info("Test didn't close all DatagramSockets!");
+				LOGGER.trace("Test didn't close all DatagramSockets!");
 				DirectDatagramSocketImpl.clearAll();
 			}
 			DirectDatagramSocketImpl.configure(DEFAULT_FORMATTER, DEFAULT_DELAY_IN_MILLIS);

--- a/element-connector/src/test/java/org/eclipse/californium/elements/rule/TestNameLoggerRule.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/rule/TestNameLoggerRule.java
@@ -29,6 +29,6 @@ public class TestNameLoggerRule extends TestWatcher {
 
 	@Override
 	protected void starting(Description description) {
-		LOGGER.info("Test {}", description.getMethodName());
+		LOGGER.trace("Test {}", description.getMethodName());
 	}
 }

--- a/element-connector/src/test/java/org/eclipse/californium/elements/rule/TestTimeRule.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/rule/TestTimeRule.java
@@ -60,7 +60,7 @@ public class TestTimeRule extends TestWatcher {
 	 * @param unit unit of time to add
 	 */
 	public final synchronized void addTestTimeShift(final long delta, final TimeUnit unit) {
-		LOGGER.debug("add {} {} to timeshift {} ns", delta, unit, timeShiftNanos);
+		LOGGER.trace("add {} {} to timeshift {} ns", delta, unit, timeShiftNanos);
 		timeShiftNanos += unit.toNanos(delta);
 	}
 
@@ -71,7 +71,7 @@ public class TestTimeRule extends TestWatcher {
 	 * @param unit unit of time shift
 	 */
 	public final synchronized void setTestTimeShift(final long shift, final TimeUnit unit) {
-		LOGGER.debug("set {} {} as timeshift", shift, unit);
+		LOGGER.trace("set {} {} as timeshift", shift, unit);
 		timeShiftNanos = unit.toNanos(shift);
 	}
 

--- a/element-connector/src/test/java/org/eclipse/californium/elements/rule/ThreadsRule.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/rule/ThreadsRule.java
@@ -182,13 +182,13 @@ public class ThreadsRule implements TestRule {
 	 * @param list list of threads
 	 */
 	public void dump(String message, List<Thread> list) {
-		LOGGER.info("Threads {}: {} threads", message, list.size());
+		LOGGER.trace("Threads {}: {} threads", message, list.size());
 		for (Thread thread : list) {
 			ThreadGroup threadGroup = thread.getThreadGroup();
 			if (threadGroup != null) {
-				LOGGER.info("Threads {} : {}-{}", description, thread.getName(), threadGroup.getName());
+				LOGGER.trace("Threads {} : {}-{}", description, thread.getName(), threadGroup.getName());
 			} else {
-				LOGGER.info("Threads {} : {}", description, thread.getName());
+				LOGGER.trace("Threads {} : {}", description, thread.getName());
 			}
 			if (LOGGER.isTraceEnabled()) {
 				StackTraceElement[] stackTrace = thread.getStackTrace();

--- a/element-connector/src/test/java/org/eclipse/californium/elements/runner/TestRepeater.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/runner/TestRepeater.java
@@ -108,9 +108,9 @@ public class TestRepeater {
 	 */
 	public void run(final Runner runner, final RunNotifier notifier) {
 		if (0 == maximumRepeats) {
-			LOGGER.info("repeat until error!");
+			LOGGER.debug("repeat until error!");
 		} else {
-			LOGGER.info("maximum repeats: {}", maximumRepeats);
+			LOGGER.debug("maximum repeats: {}", maximumRepeats);
 		}
 		// start alive logging
 		Thread alive = startAliveLogging();
@@ -170,8 +170,8 @@ public class TestRepeater {
 	private void logInfo(String tag, String format, Object... parameters) {
 		if (LOGGER.isInfoEnabled()) {
 			Runtime runtime = Runtime.getRuntime();
-			LOGGER.info(tag + ": " + format, parameters);
-			LOGGER.info(tag + ": memory free {} MByte, total {} MByte, max {} MByte", runtime.freeMemory() / MEGA_BYTE,
+			LOGGER.trace(tag + ": " + format, parameters);
+			LOGGER.trace(tag + ": memory free {} MByte, total {} MByte, max {} MByte", runtime.freeMemory() / MEGA_BYTE,
 					runtime.totalMemory() / MEGA_BYTE, runtime.maxMemory() / MEGA_BYTE);
 		}
 	}
@@ -185,7 +185,7 @@ public class TestRepeater {
 	private Thread startAliveLogging() {
 		Thread live = null;
 		if (0 < aliveIntervalInMilliseconds && LOGGER.isInfoEnabled()) {
-			LOGGER.info("start alife logging every {}ms!", aliveIntervalInMilliseconds);
+			LOGGER.trace("start alife logging every {}ms!", aliveIntervalInMilliseconds);
 			live = new Thread(new Runnable() {
 
 				@Override

--- a/element-connector/src/test/java/org/eclipse/californium/elements/util/DirectDatagramSocketImpl.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/util/DirectDatagramSocketImpl.java
@@ -628,7 +628,7 @@ public class DirectDatagramSocketImpl extends AbstractDatagramSocketImpl {
 		String message;
 		while ((message = logBuffer.poll()) != null) {
 			++counter;
-			LOGGER.info(String.format("--%02d--> %s", counter, message));
+			LOGGER.trace(String.format("--%02d--> %s", counter, message));
 		}
 	}
 

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/DTLSConnector.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/DTLSConnector.java
@@ -1446,7 +1446,7 @@ public class DTLSConnector implements Connector, RecordLayer {
 		} else {
 			// change cipher spec can only be processed within the
 			// context of an existing handshake -> ignore record
-			LOGGER.debug("Received CHANGE_CIPHER_SPEC record from peer [{}] with no handshake going on", record.getPeerAddress());
+			LOGGER.trace("Received CHANGE_CIPHER_SPEC record from peer [{}] with no handshake going on", record.getPeerAddress());
 		}
 	}
 

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/DtlsHealthLogger.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/DtlsHealthLogger.java
@@ -67,7 +67,7 @@ public class DtlsHealthLogger implements DtlsHealth {
 				log.append(head).append(droppedSentRecords).append(eol);
 				log.append(head).append(receivedRecords).append(eol);
 				log.append(head).append(droppedReceivedRecords);
-				LOGGER.debug("{}", log);
+				LOGGER.trace("{}", log);
 			}
 		} catch (Throwable e) {
 			LOGGER.error("{}", tag, e);

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/CertificateMessage.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/CertificateMessage.java
@@ -276,7 +276,7 @@ public final class CertificateMessage extends HandshakeMessage {
 			InetSocketAddress peerAddress) throws HandshakeException {
 
 		if (CertificateType.RAW_PUBLIC_KEY == certificateType) {
-			LOGGER.debug("Parsing RawPublicKey CERTIFICATE message");
+			LOGGER.trace("Parsing RawPublicKey CERTIFICATE message");
 			int certificateLength = reader.read(CERTIFICATE_LENGTH_BITS);
 			byte[] rawPublicKey = reader.readBytes(certificateLength);
 			return new CertificateMessage(rawPublicKey, peerAddress);

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/CertificateRequest.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/CertificateRequest.java
@@ -505,11 +505,11 @@ public final class CertificateRequest extends HandshakeMessage {
 	boolean isSignedWithSupportedAlgorithm(List<X509Certificate> chain) {
 		for (X509Certificate certificate : chain) {
 			if (!isSignedWithSupportedAlgorithm(certificate)) {
-				LOGGER.debug("certificate chain is NOT signed with supported algorithm(s)");
+				LOGGER.trace("certificate chain is NOT signed with supported algorithm(s)");
 				return false;
 			}
 		}
-		LOGGER.debug("certificate chain is signed with supported algorithm(s)");
+		LOGGER.trace("certificate chain is signed with supported algorithm(s)");
 		return true;
 	}
 
@@ -530,7 +530,7 @@ public final class CertificateRequest extends HandshakeMessage {
 				return true;
 			}
 		}
-		LOGGER.debug("certificate is NOT signed with supported algorithm(s)");
+		LOGGER.trace("certificate is NOT signed with supported algorithm(s)");
 		return false;
 	}
 

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ClientHandshaker.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ClientHandshaker.java
@@ -671,7 +671,7 @@ public class ClientHandshaker extends Handshaker {
 		if (maxFragmentLengthCode != null) {
 			MaxFragmentLengthExtension ext = new MaxFragmentLengthExtension(maxFragmentLengthCode); 
 			helloMessage.addExtension(ext);
-			LOGGER.debug(
+			LOGGER.trace(
 					"Indicating max. fragment length [{}] to server [{}]",
 					maxFragmentLengthCode, getPeerAddress());
 		}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/CompressionMethod.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/CompressionMethod.java
@@ -74,7 +74,7 @@ public enum CompressionMethod {
 			return CompressionMethod.DEFLATE;
 
 		default:
-			LOGGER.debug("Unknown compression method code: {}", code);
+			LOGGER.trace("Unknown compression method code: {}", code);
 			return null;
 		}
 	}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/DebugConnectionStore.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/DebugConnectionStore.java
@@ -62,11 +62,11 @@ public final class DebugConnectionStore extends InMemoryConnectionStore {
 	 */
 	public boolean dump(InetSocketAddress address) {
 		if (connections.size() == 0) {
-			LOG.info("  {}connections empty!", tag);
+			LOG.trace("  {}connections empty!", tag);
 		} else {
 			Connection connection = get(address);
 			if (connection == null) {
-				LOG.info("  {}connection: {} - not available!", tag, address);
+				LOG.trace("  {}connection: {} - not available!", tag, address);
 			} else {
 				dump(connection);
 				return true;
@@ -80,10 +80,10 @@ public final class DebugConnectionStore extends InMemoryConnectionStore {
 	 */
 	private void dump(Connection connection) {
 		if (connection.hasEstablishedSession()) {
-			LOG.info("  {}connection: {} - {} : {}", tag, connection.getConnectionId(),
+			LOG.trace("  {}connection: {} - {} : {}", tag, connection.getConnectionId(),
 					connection.getPeerAddress(), connection.getEstablishedSession().getSessionIdentifier());
 		} else {
-			LOG.info("  {}connection: {} - {}", tag, connection.getConnectionId(), connection.getPeerAddress());
+			LOG.trace("  {}connection: {} - {}", tag, connection.getConnectionId(), connection.getPeerAddress());
 		}
 	}
 

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/DtlsAeadConnectionState.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/DtlsAeadConnectionState.java
@@ -163,7 +163,7 @@ public class DtlsAeadConnectionState extends DTLSConnectionState {
 						.append(StringUtil.byteArray2HexString(explicitNonceUsed));
 				b.append(StringUtil.lineSeparator()).append("Expected: ")
 						.append(StringUtil.byteArray2HexString(explicitNonce));
-				LOGGER.debug(b.toString());
+				LOGGER.trace(b.toString());
 			}
 		}
 		byte[] payload = AeadBlockCipher.decrypt(cipherSuite, encryptionKey, nonce, additionalData, ciphertextFragment,

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Finished.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Finished.java
@@ -119,7 +119,7 @@ public final class Finished extends HandshakeMessage {
 				msg.append(StringUtil.lineSeparator()).append("Expected: ").append(StringUtil.byteArray2HexString(myVerifyData));
 				msg.append(StringUtil.lineSeparator()).append("Received: ").append(StringUtil.byteArray2HexString(verifyData));
 			}
-			LOG.debug(msg.toString());
+			LOG.trace(msg.toString());
 			AlertMessage alert = new AlertMessage(AlertLevel.FATAL, AlertDescription.HANDSHAKE_FAILURE, getPeer());
 			throw new HandshakeException("Verification of FINISHED message failed", alert);
 		}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Handshaker.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Handshaker.java
@@ -1081,7 +1081,7 @@ public abstract class Handshaker implements Destroyable {
 			deferredRecordsSize += size;
 			return true;
 		} else {
-			LOGGER.debug("Dropped incoming record from peer [{}], limit of {} bytes exceeded by {}+{} bytes!",
+			LOGGER.trace("Dropped incoming record from peer [{}], limit of {} bytes exceeded by {}+{} bytes!",
 					incomingMessage.getPeerAddress(), maxDeferredProcessedIncomingRecordsSize, deferredRecordsSize, size);
 			return false;
 		}
@@ -1174,7 +1174,7 @@ public abstract class Handshaker implements Destroyable {
 	}
 
 	protected final void handshakeStarted() throws HandshakeException {
-		LOGGER.debug("handshake started {}", connection);
+		LOGGER.trace("handshake started {}", connection);
 		for (SessionListener sessionListener : sessionListeners) {
 			sessionListener.handshakeStarted(this);
 		}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/HelloExtensions.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/HelloExtensions.java
@@ -161,7 +161,7 @@ public final class HelloExtensions {
 								new AlertMessage(AlertLevel.FATAL, AlertDescription.DECODE_ERROR, peerAddress));
 					}
 				} else {
-					LOGGER.debug("Peer included an unknown extension type code [{}] in its Hello message", typeId);
+					LOGGER.info("Peer included an unknown extension type code [{}] in its Hello message", typeId);
 				}
 			}
 

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/InMemoryConnectionStore.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/InMemoryConnectionStore.java
@@ -456,7 +456,7 @@ public class InMemoryConnectionStore implements ResumptionSupportingConnectionSt
 	@Override
 	public synchronized int remainingCapacity() {
 		int remaining = connections.remainingCapacity();
-		LOG.debug("{}connection: size {}, remaining {}!", tag, connections.size(), remaining);
+		LOG.trace("{}connection: size {}, remaining {}!", tag, connections.size(), remaining);
 		return remaining;
 	}
 

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/PskUtil.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/PskUtil.java
@@ -90,11 +90,11 @@ public class PskUtil implements Destroyable {
 		ServerNames serverNames = session.getServerNames();
 		if (sniEnabled && serverNames != null) {
 			hostName = session.getHostName();
-			LOGGER.debug("client [{}] uses PSK identity [{}] for server [{}]", session.getPeer(), pskIdentity,
+			LOGGER.info("client [{}] uses PSK identity [{}] for server [{}]", session.getPeer(), pskIdentity,
 					hostName);
 			pskSecret = pskStore.getKey(serverNames, pskIdentity);
 		} else {
-			LOGGER.debug("client [{}] uses PSK identity [{}]", session.getPeer(), pskIdentity);
+			LOGGER.info("client [{}] uses PSK identity [{}]", session.getPeer(), pskIdentity);
 			pskSecret = pskStore.getKey(pskIdentity);
 		}
 		if (pskSecret == null) {

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ResumingClientHandshaker.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ResumingClientHandshaker.java
@@ -133,7 +133,7 @@ public class ResumingClientHandshaker extends ClientHandshaker {
 	protected void receivedServerHello(ServerHello message) throws HandshakeException {
 		if (!session.getSessionIdentifier().equals(message.getSessionId()))
 		{
-			LOGGER.debug(
+			LOGGER.info(
 					"Server [{}] refuses to resume session [{}], performing full handshake instead...",
 					message.getPeer(), session.getSessionIdentifier());
 			// Server refuse to resume the session, go for a full handshake

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ServerHandshaker.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ServerHandshaker.java
@@ -707,7 +707,7 @@ public class ServerHandshaker extends Handshaker {
 					session.setCipherSuite(cipherSuite);
 					addServerHelloExtensions(cipherSuite, clientHello, serverHelloExtensions);
 					session.setParameterAvailable();
-					LOGGER.debug("Negotiated cipher suite [{}] with peer [{}]",
+					LOGGER.info("Negotiated cipher suite [{}] with peer [{}]",
 							cipherSuite.name(), getPeerAddress());
 					return;
 				}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/x509/StaticCertificateVerifier.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/x509/StaticCertificateVerifier.java
@@ -81,7 +81,7 @@ public class StaticCertificateVerifier implements CertificateVerifier {
 
 		} catch (GeneralSecurityException e) {
 			if (LOGGER.isTraceEnabled()) {
-				LOGGER.trace("Certificate validation failed", e);
+				LOGGER.debug("Certificate validation failed", e);
 			} else if (LOGGER.isDebugEnabled()) {
 				LOGGER.debug("Certificate validation failed due to {}", e.getMessage());
 			}

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/ReassemblingHandshakeMessageTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/ReassemblingHandshakeMessageTest.java
@@ -96,7 +96,7 @@ public class ReassemblingHandshakeMessageTest {
 	}
 
 	private void log(FragmentedHandshakeMessage msg) {
-		LOGGER.info(" fragment [{}:{})", msg.getFragmentOffset(), msg.getFragmentOffset() + msg.getFragmentLength());
+		LOGGER.trace(" fragment [{}:{})", msg.getFragmentOffset(), msg.getFragmentOffset() + msg.getFragmentLength());
 	}
 
 	private void log() {
@@ -107,9 +107,9 @@ public class ReassemblingHandshakeMessageTest {
 
 	private void log(ReassemblingHandshakeMessage reassembledMessage) {
 		List<Object> ranges = reassembledMessage.getRanges();
-		LOGGER.info("{} ranges", ranges.size());
+		LOGGER.trace("{} ranges", ranges.size());
 		for (Object range : ranges) {
-			LOGGER.info("  {}", range);
+			LOGGER.trace("  {}", range);
 		}
 	}
 


### PR DESCRIPTION
We appreciate your previous feedback and it's very helpful! Here's a reissue of https://github.com/eclipse/californium/pull/933 with a new version of our tool.  Again, we'd appreciate any feedback and are willing to make further changes if you wish to incorporate our PR into your project.

Settings
---
We have several analysis settings. We can vary these settings and rerun if you desire. The settings we are using in this pull request are:

- Treat ERROR/WARN levels as a category and not a traditional level, i.e., our tool ignores these log levels.
- Consistent log level transformations between overriding methods.

The greatest number of commits from HEAD evaluated: 1000.
The head at the time of analysis was: 785267fc8a2486260e1e65144ebaf6ca1c1ac81b


- [x] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/selenium/blob/master/CONTRIBUTING.md#step-6-sign-the-cla)

