### PR TITLE
Rejuvenate log levels

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/network/CoapEndpointHealthLogger.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/CoapEndpointHealthLogger.java
@@ -64,7 +64,7 @@ public class CoapEndpointHealthLogger implements CoapEndpointHealth {
 				log.append(head).append(receivedRejects).append(eol);
 				log.append(head).append(duplicateRequests).append(eol);
 				log.append(head).append(duplicateResponses);
-				LOGGER.debug("{}", log);
+				LOGGER.trace("{}", log);
 			}
 		} catch (Throwable e) {
 			LOGGER.error("{}", tag, e);

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/RandomTokenGenerator.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/RandomTokenGenerator.java
@@ -63,7 +63,7 @@ public class RandomTokenGenerator implements TokenGenerator {
 		// trigger self-seeding of the PRNG, may "take a while"
 		this.rng.nextInt(10);
 		this.tokenSize = networkConfig.getInt(Keys.TOKEN_SIZE_LIMIT, DEFAULT_TOKEN_LENGTH);
-		LOGGER.info("using tokens of {} bytes in length", this.tokenSize);
+		LOGGER.trace("using tokens of {} bytes in length", this.tokenSize);
 	}
 
 	@Override

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/Block2BlockwiseStatus.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/Block2BlockwiseStatus.java
@@ -149,7 +149,7 @@ public final class Block2BlockwiseStatus extends BlockwiseStatus {
 				return block2.getSzx();
 			}
 		}
-		LOGGER.debug("using default preferred block size for response: {}", preferredBlockSize);
+		LOGGER.trace("using default preferred block size for response: {}", preferredBlockSize);
 		return BlockOption.size2Szx(preferredBlockSize);
 	}
 

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/CountingCoapHandler.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/CountingCoapHandler.java
@@ -74,7 +74,7 @@ public class CountingCoapHandler implements CoapHandler {
 			}
 			notifyAll();
 		}
-		LOGGER.info("Received {}. Notification: {}", counter, response.advanced());
+		LOGGER.trace("Received {}. Notification: {}", counter, response.advanced());
 	}
 
 	/**

--- a/californium-osgi/src/main/java/org/eclipse/californium/osgi/ManagedServer.java
+++ b/californium-osgi/src/main/java/org/eclipse/californium/osgi/ManagedServer.java
@@ -216,7 +216,7 @@ public class ManagedServer implements ManagedService, ServiceTrackerCustomizer<R
 	@Override
 	public Resource addingService(ServiceReference<Resource> reference) {
 		Resource resource = context.getService(reference);
-		LOGGER.debug("Adding resource [{}]", resource.getName());
+		LOGGER.trace("Adding resource [{}]", resource.getName());
 		if (resource != null) {
 			managedServer.add(resource);
 		}
@@ -235,7 +235,7 @@ public class ManagedServer implements ManagedService, ServiceTrackerCustomizer<R
 	@Override
 	public void removedService(ServiceReference<Resource> reference,
 			Resource service) {
-		LOGGER.debug("Removing resource [{}]", service.getName());
+		LOGGER.trace("Removing resource [{}]", service.getName());
 		managedServer.remove(service);
 		context.ungetService(reference);
 	}

--- a/californium-proxy/src/main/java/org/eclipse/californium/proxy/CoapTranslator.java
+++ b/californium-proxy/src/main/java/org/eclipse/californium/proxy/CoapTranslator.java
@@ -128,7 +128,7 @@ public final class CoapTranslator {
 			outgoingRequest.setURI(serverUri);
 		}
 
-		LOGGER.debug("Incoming request translated correctly");
+		LOGGER.trace("Incoming request translated correctly");
 		return outgoingRequest;
 	}
 	
@@ -166,7 +166,7 @@ public final class CoapTranslator {
 		outgoingResponse.setOptions(new OptionSet(
 				incomingResponse.getOptions()));
 		
-		LOGGER.debug("Incoming response translated correctly");
+		LOGGER.trace("Incoming response translated correctly");
 		return outgoingResponse;
 	}
 

--- a/californium-proxy/src/main/java/org/eclipse/californium/proxy/DirectProxyCoapResolver.java
+++ b/californium-proxy/src/main/java/org/eclipse/californium/proxy/DirectProxyCoapResolver.java
@@ -47,7 +47,7 @@ public class DirectProxyCoapResolver implements ProxyCoapResolver {
 
 	@Override
 	public void forwardRequest(Exchange exchange) {
-		LOGGER.debug("Forward CoAP request to ProxyCoap2Coap: {}", exchange.getRequest());
+		LOGGER.trace("Forward CoAP request to ProxyCoap2Coap: {}", exchange.getRequest());
 		proxyCoapClientResource.handleRequest(exchange);
 	}
 }

--- a/californium-proxy/src/main/java/org/eclipse/californium/proxy/HttpRequestContext.java
+++ b/californium-proxy/src/main/java/org/eclipse/californium/proxy/HttpRequestContext.java
@@ -64,7 +64,7 @@ public final class HttpRequestContext {
 			// translate the coap response in an http response
 			new HttpTranslator().getHttpResponse(httpRequest, coapResponse, httpResponse);
 
-			LOGGER.debug("Outgoing http response: {}", httpResponse.getStatusLine());
+			LOGGER.trace("Outgoing http response: {}", httpResponse.getStatusLine());
 		} catch (TranslationException e) {
 			LOGGER.warn("Failed to translate coap response to http response: {}", e.getMessage());
 			sendSimpleHttpResponse(HttpTranslator.STATUS_TRANSLATION_ERROR);

--- a/californium-proxy/src/main/java/org/eclipse/californium/proxy/HttpStack.java
+++ b/californium-proxy/src/main/java/org/eclipse/californium/proxy/HttpStack.java
@@ -191,7 +191,7 @@ public class HttpStack {
 				// Create server-side I/O reactor
 				ioReactor = new DefaultListeningIOReactor();
 				// Listen of the given port
-				LOGGER.info("HttpStack listening on port {}", httpPort);
+				LOGGER.debug("HttpStack listening on port {}", httpPort);
 				ioReactor.listen(new InetSocketAddress(httpPort));
 
 				// create the listener thread
@@ -202,7 +202,7 @@ public class HttpStack {
 						// Starts the reactor and initiates the dispatch of I/O
 						// event notifications to the given IOEventDispatch.
 						try {
-							LOGGER.info("Submitted http listening to thread 'HttpStack listener'");
+							LOGGER.debug("Submitted http listening to thread 'HttpStack listener'");
 
 							ioReactor.execute(ioEventDispatch);
 						} catch (IOException e) {
@@ -240,7 +240,7 @@ public class HttpStack {
 				httpResponse.setEntity(new StringEntity("Californium Proxy server"));
 
 //				if (Bench_Help.DO_LOG) 
-					LOGGER.debug("Root request handled");
+					LOGGER.trace("Root request handled");
 			}
 		}
 
@@ -288,7 +288,7 @@ public class HttpStack {
 					// translate the request in a valid coap request
 					Request coapRequest = new HttpTranslator().getCoapRequest(httpRequest, localResource, proxyingEnabled);
 //					if (Bench_Help.DO_LOG) 
-						LOGGER.info("Received HTTP request and translate to {}", coapRequest);
+						LOGGER.debug("Received HTTP request and translate to {}", coapRequest);
 
 					// handle the requset
 					requestHandler.handleRequest(coapRequest, httpRequestContext);

--- a/californium-proxy/src/main/java/org/eclipse/californium/proxy/ProxyHttpServer.java
+++ b/californium-proxy/src/main/java/org/eclipse/californium/proxy/ProxyHttpServer.java
@@ -85,7 +85,7 @@ public class ProxyHttpServer {
 
 	public void handleRequest(final Request request, final HttpRequestContext context) {
 		
-		LOGGER.info("ProxyEndpoint handles request {}", request);
+		LOGGER.trace("ProxyEndpoint handles request {}", request);
 		
 		Exchange exchange = new Exchange(request, Origin.REMOTE, null) {
 
@@ -106,7 +106,7 @@ public class ProxyHttpServer {
 				request.setResponse(response);
 				responseProduced(request, response);
 				context.handleRequestForwarding(response);
-				LOGGER.info("HTTP returned {}", response);
+				LOGGER.trace("HTTP returned {}", response);
 			}
 		};
 		exchange.setRequest(request);
@@ -119,7 +119,7 @@ public class ProxyHttpServer {
 			// get the response from the cache
 			response = cacheResource.getResponse(request);
 
-				LOGGER.info("Cache returned {}", response);
+				LOGGER.trace("Cache returned {}", response);
 
 			// update statistics
 			statsResource.updateStatistics(request, response != null);
@@ -138,7 +138,7 @@ public class ProxyHttpServer {
 			if (request.getOptions().hasProxyUri()) {
 				try {
 					manageProxyUriRequest(request);
-					LOGGER.info("after manageProxyUriRequest: {}", request);
+					LOGGER.trace("after manageProxyUriRequest: {}", request);
 
 				} catch (URISyntaxException e) {
 					LOGGER.warn(String.format("Proxy-uri malformed: %s", request.getOptions().getProxyUri()));
@@ -184,7 +184,7 @@ public class ProxyHttpServer {
 			clientPath = PROXY_COAP_CLIENT;
 		}
 
-		LOGGER.info("Chose {} as clientPath", clientPath);
+		LOGGER.trace("Chose {} as clientPath", clientPath);
 
 		// set the path in the request to be forwarded correctly
 		request.getOptions().setUriPath(clientPath);

--- a/californium-proxy/src/main/java/org/eclipse/californium/proxy/resources/ProxyCoapClientResource.java
+++ b/californium-proxy/src/main/java/org/eclipse/californium/proxy/resources/ProxyCoapClientResource.java
@@ -80,7 +80,7 @@ public class ProxyCoapClientResource extends ForwardingResource {
 
 				@Override
 				public void onResponse(Response incomingResponse) {
-					LOGGER.debug("ProxyCoapClientResource received {}", incomingResponse);
+					LOGGER.trace("ProxyCoapClientResource received {}", incomingResponse);
 					future.complete(CoapTranslator.getResponse(incomingResponse));
 					EndPointManagerPool.putClient(endpointManager);
 				}

--- a/californium-proxy/src/main/java/org/eclipse/californium/proxy/resources/ProxyHttpClientResource.java
+++ b/californium-proxy/src/main/java/org/eclipse/californium/proxy/resources/ProxyHttpClientResource.java
@@ -118,7 +118,7 @@ public class ProxyHttpClientResource extends ForwardingResource {
 			@Override
 			public void completed(HttpResponse result) {
 				long timestamp = ClockUtil.nanoRealtime();
-				LOGGER.debug("Incoming http response: {}", result.getStatusLine());
+				LOGGER.trace("Incoming http response: {}", result.getStatusLine());
 				// the entity of the response, if non repeatable, could be
 				// consumed only one time, so do not debug it!
 				// System.out.println(EntityUtils.toString(httpResponse.getEntity()));

--- a/cf-oscore/src/main/java/org/eclipse/californium/oscore/ObjectSecurityContextLayer.java
+++ b/cf-oscore/src/main/java/org/eclipse/californium/oscore/ObjectSecurityContextLayer.java
@@ -141,7 +141,7 @@ public class ObjectSecurityContextLayer extends AbstractLayer {
 
 					});
 					// send start rederivation request
-					LOGGER.info("Auxiliary Request: " + exchange.getRequest().toString());
+					LOGGER.trace("Auxiliary Request: " + exchange.getRequest().toString());
 					final Exchange newExchange = new Exchange(startRederivation, Origin.LOCAL, executor);
 					newExchange.execute(new Runnable() {
 
@@ -161,7 +161,7 @@ public class ObjectSecurityContextLayer extends AbstractLayer {
 				return;
 			}
 		}
-		LOGGER.info("Request: " + exchange.getRequest().toString());
+		LOGGER.trace("Request: " + exchange.getRequest().toString());
 		super.sendRequest(exchange, request);
 	}
 

--- a/demo-apps/cf-extplugtest-client/src/main/java/org/eclipse/californium/extplugtests/BenchmarkClient.java
+++ b/demo-apps/cf-extplugtest-client/src/main/java/org/eclipse/californium/extplugtests/BenchmarkClient.java
@@ -375,7 +375,7 @@ public class BenchmarkClient {
 					next();
 				}
 				long c = overallRequestsDownCounter.get();
-				LOGGER.info("Received response: {} {}", response.advanced(), c);
+				LOGGER.trace("Received response: {} {}", response.advanced(), c);
 			} else {
 				long c = requestsCounter.get();
 				LOGGER.warn("Received error response: {} {} ({} successful)", endpoint.getUri(), response.advanced(), c);
@@ -974,21 +974,21 @@ public class BenchmarkClient {
 		if (tag != null) {
 			// with tag, use file
 			logger = LoggerFactory.getLogger(logger.getName() + ".file");
-			logger.info("------- {} ------------------------------------------------", tag);
-			logger.info("{}, {}, {}", osMxBean.getName(), osMxBean.getVersion(), osMxBean.getArch());
+			logger.trace("------- {} ------------------------------------------------", tag);
+			logger.trace("{}, {}, {}", osMxBean.getName(), osMxBean.getVersion(), osMxBean.getArch());
 			StringBuilder line = new StringBuilder();
 			List<String> vmArgs = ManagementFactory.getRuntimeMXBean().getInputArguments();
 			for (String arg : vmArgs) {
 				line.append(arg).append(" ");
 			}
-			logger.info("{}", line);
+			logger.trace("{}", line);
 			line.setLength(0);
 			for (String arg : args) {
 				line.append(arg).append(" ");
 			}
-			logger.info("{}", line);
+			logger.trace("{}", line);
 		}
-		logger.info("uptime: {} ms, {} processors", TimeUnit.NANOSECONDS.toMillis(uptimeNanos), processors);
+		logger.trace("uptime: {} ms, {} processors", TimeUnit.NANOSECONDS.toMillis(uptimeNanos), processors);
 		ThreadMXBean threadMxBean = ManagementFactory.getThreadMXBean();
 		if (threadMxBean.isThreadCpuTimeSupported() && threadMxBean.isThreadCpuTimeEnabled()) {
 			long alltime = 0;
@@ -1000,7 +1000,7 @@ public class BenchmarkClient {
 				}
 			}
 			long pTime = alltime / processors;
-			logger.info("cpu-time: {} ms (per-processor: {} ms, load: {}%)",
+			logger.trace("cpu-time: {} ms (per-processor: {} ms, load: {}%)",
 					TimeUnit.NANOSECONDS.toMillis(alltime), TimeUnit.NANOSECONDS.toMillis(pTime),
 					(pTime * 100) / uptimeNanos);
 		}
@@ -1016,7 +1016,7 @@ public class BenchmarkClient {
 				gcTime += time;
 			}
 		}
-		logger.info("gc: {} ms, {} calls", gcTime, gcCount);
+		logger.trace("gc: {} ms, {} calls", gcTime, gcCount);
 		double loadAverage = osMxBean.getSystemLoadAverage();
 		if (!(loadAverage < 0.0d)) {
 			logger.info("average load: {}", String.format("%.2f", loadAverage));

--- a/demo-apps/cf-extplugtest-client/src/main/java/org/eclipse/californium/extplugtests/resources/Feed.java
+++ b/demo-apps/cf-extplugtest-client/src/main/java/org/eclipse/californium/extplugtests/resources/Feed.java
@@ -219,7 +219,7 @@ public class Feed extends CoapResource {
 							response.getToken());
 				} else {
 					timeout = 0;
-					LOGGER.info("client[{}] next change in {} ms, {} observer.", id, interval, observer);
+					LOGGER.trace("client[{}] next change in {} ms, {} observer.", id, interval, observer);
 					executorService.schedule(change, interval, TimeUnit.MILLISECONDS);
 				}
 			} else {

--- a/demo-apps/cf-extplugtest-server/src/main/java/org/eclipse/californium/extplugtests/ExtendedTestServer.java
+++ b/demo-apps/cf-extplugtest-server/src/main/java/org/eclipse/californium/extplugtests/ExtendedTestServer.java
@@ -231,7 +231,7 @@ public class ExtendedTestServer extends AbstractTestServer {
 		OperatingSystemMXBean osMxBean = ManagementFactory.getOperatingSystemMXBean();
 		int processors = osMxBean.getAvailableProcessors();
 		Logger logger = STATISTIC_LOGGER;
-		logger.info("{} processors", processors);
+		logger.trace("{} processors", processors);
 		ThreadMXBean threadMxBean = ManagementFactory.getThreadMXBean();
 		if (threadMxBean.isThreadCpuTimeSupported() && threadMxBean.isThreadCpuTimeEnabled()) {
 			long alltime = 0;
@@ -243,7 +243,7 @@ public class ExtendedTestServer extends AbstractTestServer {
 				}
 			}
 			long pTime = alltime / processors;
-			logger.info("cpu-time: {} ms (per-processor: {} ms)",
+			logger.trace("cpu-time: {} ms (per-processor: {} ms)",
 					TimeUnit.NANOSECONDS.toMillis(alltime), TimeUnit.NANOSECONDS.toMillis(pTime));
 		}
 		long gcCount = 0;
@@ -258,7 +258,7 @@ public class ExtendedTestServer extends AbstractTestServer {
 				gcTime += time;
 			}
 		}
-		logger.info("gc: {} ms, {} calls", gcTime, gcCount);
+		logger.trace("gc: {} ms, {} calls", gcTime, gcCount);
 		double loadAverage = osMxBean.getSystemLoadAverage();
 		if (!(loadAverage < 0.0d)) {
 			logger.info("average load: {}", String.format("%.2f", loadAverage));

--- a/demo-apps/cf-extplugtest-server/src/main/java/org/eclipse/californium/extplugtests/resources/ReverseObserve.java
+++ b/demo-apps/cf-extplugtest-server/src/main/java/org/eclipse/californium/extplugtests/resources/ReverseObserve.java
@@ -429,7 +429,7 @@ public class ReverseObserve extends CoapResource implements NotificationListener
 		private void remove(ResponseCode code) {
 			String key = incomingExchange.getPeerKey();
 			observesByPeer.remove(key);
-			LOGGER.info("Removed observation for {}", key);
+			LOGGER.trace("Removed observation for {}", key);
 			incomingExchange.respond(code);
 		}
 	}

--- a/demo-apps/cf-extplugtest-server/src/main/java/org/eclipse/californium/extplugtests/resources/ReverseRequest.java
+++ b/demo-apps/cf-extplugtest-server/src/main/java/org/eclipse/californium/extplugtests/resources/ReverseRequest.java
@@ -185,8 +185,8 @@ public class ReverseRequest extends CoapResource {
 			if (overallSentRequests.getAndIncrement() == 0) {
 				LOGGER.info("start reverse requests!");
 			}
-			LOGGER.debug("{}", request);
-			LOGGER.info("{}/{}: {} reverse requests, {} overall.", request.getSourceContext().getPeerAddress(),
+			LOGGER.trace("{}", request);
+			LOGGER.trace("{}/{}: {} reverse requests, {} overall.", request.getSourceContext().getPeerAddress(),
 					resource, numberOfRequests, overall);
 			Endpoint endpoint = exchange.advanced().getEndpoint();
 			exchange.respond(CHANGED);

--- a/demo-apps/cf-nat/src/main/java/org/eclipse/californium/examples/NatUtil.java
+++ b/demo-apps/cf-nat/src/main/java/org/eclipse/californium/examples/NatUtil.java
@@ -556,7 +556,7 @@ public class NatUtil implements Runnable {
 		} else {
 			forward = new MessageDropping("request", percent);
 			backward = new MessageDropping("responses", percent);
-			LOGGER.info("NAT message dropping {}%.", percent);
+			LOGGER.trace("NAT message dropping {}%.", percent);
 		}
 	}
 
@@ -577,7 +577,7 @@ public class NatUtil implements Runnable {
 			}
 		} else {
 			forward = new MessageDropping("request", percent);
-			LOGGER.info("NAT forward message dropping {}%.", percent);
+			LOGGER.trace("NAT forward message dropping {}%.", percent);
 		}
 	}
 
@@ -598,7 +598,7 @@ public class NatUtil implements Runnable {
 			}
 		} else {
 			backward = new MessageDropping("response", percent);
-			LOGGER.info("NAT backward message dropping {}%.", percent);
+			LOGGER.trace("NAT backward message dropping {}%.", percent);
 		}
 	}
 
@@ -624,7 +624,7 @@ public class NatUtil implements Runnable {
 			}
 		} else {
 			reorder = new MessageReordering("reordering", percent, delayMillis, randomDelayMillis);
-			LOGGER.info("NAT message reordering {}%.", percent);
+			LOGGER.trace("NAT message reordering {}%.", percent);
 		}
 	}
 

--- a/demo-apps/cf-plugtest-checker/src/main/java/org/eclipse/californium/plugtests/LinkParser.java
+++ b/demo-apps/cf-plugtest-checker/src/main/java/org/eclipse/californium/plugtests/LinkParser.java
@@ -48,7 +48,7 @@ public class LinkParser {
 				if (path.startsWith("/")) {
 					path = path.substring(1);
 				}
-				LOG.debug("Parsing link resource: {}", path);
+				LOG.trace("Parsing link resource: {}", path);
 				Resource resource = new CoapResource(path);
 				for (String attrName : link.getAttributes().getAttributeKeySet()) {
 					for (String attrValue : link.getAttributes().getAttributeValues(attrName)) {

--- a/element-connector/src/main/java/org/eclipse/californium/elements/util/PemReader.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/util/PemReader.java
@@ -53,7 +53,7 @@ public class PemReader {
 			Matcher matcher = BEGIN_PATTERN.matcher(line);
 			if (matcher.matches()) {
 				tag = matcher.group(1);
-				LOGGER.debug("Found Begin of {}", tag);
+				LOGGER.trace("Found Begin of {}", tag);
 				break;
 			}
 		}
@@ -70,7 +70,7 @@ public class PemReader {
 				String end = matcher.group(1);
 				if (end.equals(tag)) {
 					byte[] decode = Base64.decode(buffer.toString());
-					LOGGER.debug("Found End of {}", tag);
+					LOGGER.trace("Found End of {}", tag);
 					return decode;
 				} else {
 					LOGGER.warn("Found End of {}, but expected {}!", end, tag);

--- a/element-connector/src/test/java/org/eclipse/californium/elements/rule/TestNameLoggerRule.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/rule/TestNameLoggerRule.java
@@ -29,6 +29,6 @@ public class TestNameLoggerRule extends TestWatcher {
 
 	@Override
 	protected void starting(Description description) {
-		LOGGER.info("Test {}", description.getMethodName());
+		LOGGER.trace("Test {}", description.getMethodName());
 	}
 }

--- a/element-connector/src/test/java/org/eclipse/californium/elements/rule/TestTimeRule.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/rule/TestTimeRule.java
@@ -60,7 +60,7 @@ public class TestTimeRule extends TestWatcher {
 	 * @param unit unit of time to add
 	 */
 	public final synchronized void addTestTimeShift(final long delta, final TimeUnit unit) {
-		LOGGER.debug("add {} {} to timeshift {} ns", delta, unit, timeShiftNanos);
+		LOGGER.trace("add {} {} to timeshift {} ns", delta, unit, timeShiftNanos);
 		timeShiftNanos += unit.toNanos(delta);
 	}
 
@@ -71,7 +71,7 @@ public class TestTimeRule extends TestWatcher {
 	 * @param unit unit of time shift
 	 */
 	public final synchronized void setTestTimeShift(final long shift, final TimeUnit unit) {
-		LOGGER.debug("set {} {} as timeshift", shift, unit);
+		LOGGER.trace("set {} {} as timeshift", shift, unit);
 		timeShiftNanos = unit.toNanos(shift);
 	}
 

--- a/element-connector/src/test/java/org/eclipse/californium/elements/rule/ThreadsRule.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/rule/ThreadsRule.java
@@ -182,7 +182,7 @@ public class ThreadsRule implements TestRule {
 	 * @param list list of threads
 	 */
 	public void dump(String message, List<Thread> list) {
-		LOGGER.info("Threads {}: {} threads", message, list.size());
+		LOGGER.trace("Threads {}: {} threads", message, list.size());
 		for (Thread thread : list) {
 			ThreadGroup threadGroup = thread.getThreadGroup();
 			if (threadGroup != null) {

--- a/element-connector/src/test/java/org/eclipse/californium/elements/util/DirectDatagramSocketImpl.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/util/DirectDatagramSocketImpl.java
@@ -628,7 +628,7 @@ public class DirectDatagramSocketImpl extends AbstractDatagramSocketImpl {
 		String message;
 		while ((message = logBuffer.poll()) != null) {
 			++counter;
-			LOGGER.info(String.format("--%02d--> %s", counter, message));
+			LOGGER.trace(String.format("--%02d--> %s", counter, message));
 		}
 	}
 

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/DtlsHealthLogger.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/DtlsHealthLogger.java
@@ -67,7 +67,7 @@ public class DtlsHealthLogger implements DtlsHealth {
 				log.append(head).append(droppedSentRecords).append(eol);
 				log.append(head).append(receivedRecords).append(eol);
 				log.append(head).append(droppedReceivedRecords);
-				LOGGER.debug("{}", log);
+				LOGGER.trace("{}", log);
 			}
 		} catch (Throwable e) {
 			LOGGER.error("{}", tag, e);

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/CertificateRequest.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/CertificateRequest.java
@@ -509,7 +509,7 @@ public final class CertificateRequest extends HandshakeMessage {
 				return false;
 			}
 		}
-		LOGGER.debug("certificate chain is signed with supported algorithm(s)");
+		LOGGER.trace("certificate chain is signed with supported algorithm(s)");
 		return true;
 	}
 
@@ -530,7 +530,7 @@ public final class CertificateRequest extends HandshakeMessage {
 				return true;
 			}
 		}
-		LOGGER.debug("certificate is NOT signed with supported algorithm(s)");
+		LOGGER.trace("certificate is NOT signed with supported algorithm(s)");
 		return false;
 	}
 

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ClientHandshaker.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ClientHandshaker.java
@@ -671,7 +671,7 @@ public class ClientHandshaker extends Handshaker {
 		if (maxFragmentLengthCode != null) {
 			MaxFragmentLengthExtension ext = new MaxFragmentLengthExtension(maxFragmentLengthCode); 
 			helloMessage.addExtension(ext);
-			LOGGER.debug(
+			LOGGER.trace(
 					"Indicating max. fragment length [{}] to server [{}]",
 					maxFragmentLengthCode, getPeerAddress());
 		}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Finished.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Finished.java
@@ -119,7 +119,7 @@ public final class Finished extends HandshakeMessage {
 				msg.append(StringUtil.lineSeparator()).append("Expected: ").append(StringUtil.byteArray2HexString(myVerifyData));
 				msg.append(StringUtil.lineSeparator()).append("Received: ").append(StringUtil.byteArray2HexString(verifyData));
 			}
-			LOG.debug(msg.toString());
+			LOG.trace(msg.toString());
 			AlertMessage alert = new AlertMessage(AlertLevel.FATAL, AlertDescription.HANDSHAKE_FAILURE, getPeer());
 			throw new HandshakeException("Verification of FINISHED message failed", alert);
 		}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/InMemoryConnectionStore.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/InMemoryConnectionStore.java
@@ -456,7 +456,7 @@ public class InMemoryConnectionStore implements ResumptionSupportingConnectionSt
 	@Override
 	public synchronized int remainingCapacity() {
 		int remaining = connections.remainingCapacity();
-		LOG.debug("{}connection: size {}, remaining {}!", tag, connections.size(), remaining);
+		LOG.trace("{}connection: size {}, remaining {}!", tag, connections.size(), remaining);
 		return remaining;
 	}
 

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/ReassemblingHandshakeMessageTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/ReassemblingHandshakeMessageTest.java
@@ -96,7 +96,7 @@ public class ReassemblingHandshakeMessageTest {
 	}
 
 	private void log(FragmentedHandshakeMessage msg) {
-		LOGGER.info(" fragment [{}:{})", msg.getFragmentOffset(), msg.getFragmentOffset() + msg.getFragmentLength());
+		LOGGER.trace(" fragment [{}:{})", msg.getFragmentOffset(), msg.getFragmentOffset() + msg.getFragmentLength());
 	}
 
 	private void log() {
@@ -107,9 +107,9 @@ public class ReassemblingHandshakeMessageTest {
 
 	private void log(ReassemblingHandshakeMessage reassembledMessage) {
 		List<Object> ranges = reassembledMessage.getRanges();
-		LOGGER.info("{} ranges", ranges.size());
+		LOGGER.trace("{} ranges", ranges.size());
 		for (Object range : ranges) {
-			LOGGER.info("  {}", range);
+			LOGGER.trace("  {}", range);
 		}
 	}
 


### PR DESCRIPTION
We appreciate your previous feedback and it's very helpful! Here's a reissue of https://github.com/eclipse/californium/pull/933 with a new version of our tool.  Again, we'd appreciate any feedback and are willing to make further changes if you wish to incorporate our PR into your project.

Settings
---
We have several analysis settings. We can vary these settings and rerun if you desire. The settings we are using in this pull request are:

- Treat ERROR/WARN levels as a category and not a traditional level, i.e., our tool ignores these log levels.
- Never lower the logging level of logging statements within catch blocks.
- Never lower the logging level of logging statements within if statements.
- Never lower the logging level of logging statements containing certain (important) keywords.
- Never raise the logging level of logging statements without particular keywords in their messages.
- Avoid log wrapping by disregarding logging statements contained in if statements mentioning log levels.
- Consistent log level transformations between overriding methods.

The greatest number of commits from HEAD evaluated: 1000.
The head at the time of analysis was: 785267fc8a2486260e1e65144ebaf6ca1c1ac81b


- [x] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/selenium/blob/master/CONTRIBUTING.md#step-6-sign-the-cla)

