### PR TITLE
Rejuvenate log levels

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/Request.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/Request.java
@@ -257,7 +257,7 @@ public class Request extends Message {
 			String coapUri = uri;
 			if (!uri.contains("://")) {
 				coapUri = "coap://" + uri;
-				LOGGER.warn("update your code to supply an RFC 7252 compliant URI including a scheme");
+				LOGGER.debug("update your code to supply an RFC 7252 compliant URI including a scheme");
 			}
 			return setURI(new URI(coapUri));
 		} catch (URISyntaxException e) {

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/CoapEndpointHealthLogger.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/CoapEndpointHealthLogger.java
@@ -68,7 +68,7 @@ public class CoapEndpointHealthLogger implements CoapEndpointHealth {
 				log.append(head).append(receivedRejects).append(eol);
 				log.append(head).append(duplicateRequests).append(eol);
 				log.append(head).append(duplicateResponses);
-				LOGGER.debug("{}", log);
+				LOGGER.trace("{}", log);
 			}
 		} catch (Throwable e) {
 			LOGGER.error("{}", tag, e);

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/EndpointManager.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/EndpointManager.java
@@ -247,7 +247,7 @@ public class EndpointManager {
 
 		@Override
 		public void deliverRequest(Exchange exchange) {
-			LOGGER.error("Default endpoint without CoapServer has received a request.");
+			LOGGER.info("Default endpoint without CoapServer has received a request.");
 			exchange.sendReject();
 		}
 

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/InMemoryMessageExchangeStore.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/InMemoryMessageExchangeStore.java
@@ -487,12 +487,12 @@ public class InMemoryMessageExchangeStore implements MessageExchangeStore {
 			Request current = exchange.getCurrentRequest();
 			String pending = exchange.getRetransmissionHandle() == null ? "" : "/pending";
 			if (origin != current && !origin.getToken().equals(current.getToken())) {
-				HEALTH_LOGGER.debug("  {}, {}, retransmission {}{}, org {}, {}, {}", exchangeEntry.getKey(),
+				HEALTH_LOGGER.warn("  {}, {}, retransmission {}{}, org {}, {}, {}", exchangeEntry.getKey(),
 						exchange, exchange.getFailedTransmissionCount(), pending, origin.getToken(),
 						current, exchange.getCurrentResponse());
 			} else {
 				String mark = origin == null ? "(missing origin request) " : "";
-				HEALTH_LOGGER.debug("  {}, {}, retransmission {}{}, {}{}, {}", exchangeEntry.getKey(),
+				HEALTH_LOGGER.warn("  {}, {}, retransmission {}{}, {}{}, {}", exchangeEntry.getKey(),
 						exchange, exchange.getFailedTransmissionCount(), pending, mark, current,
 						exchange.getCurrentResponse());
 			}

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/RandomTokenGenerator.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/RandomTokenGenerator.java
@@ -63,7 +63,7 @@ public class RandomTokenGenerator implements TokenGenerator {
 		// trigger self-seeding of the PRNG, may "take a while"
 		this.rng.nextInt(10);
 		this.tokenSize = networkConfig.getInt(Keys.TOKEN_SIZE_LIMIT, DEFAULT_TOKEN_LENGTH);
-		LOGGER.info("using tokens of {} bytes in length", this.tokenSize);
+		LOGGER.trace("using tokens of {} bytes in length", this.tokenSize);
 	}
 
 	@Override

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/AbstractLayer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/AbstractLayer.java
@@ -192,12 +192,12 @@ public abstract class AbstractLayer implements Layer {
 
 		@Override
 		public void sendRequest(final Exchange exchange, final Request request) {
-			LOGGER.error("No lower layer set for sending request [{}]", request);
+			LOGGER.info("No lower layer set for sending request [{}]", request);
 		}
 
 		@Override
 		public void sendResponse(final Exchange exchange, final Response response) {
-			LOGGER.error("No lower layer set for sending response [{}]", response);
+			LOGGER.info("No lower layer set for sending response [{}]", response);
 		}
 
 		@Override
@@ -207,12 +207,12 @@ public abstract class AbstractLayer implements Layer {
 
 		@Override
 		public void receiveRequest(final Exchange exchange, final Request request) {
-			LOGGER.error("No upper layer set for receiving request [{}]", request);
+			LOGGER.info("No upper layer set for receiving request [{}]", request);
 		}
 
 		@Override
 		public void receiveResponse(final Exchange exchange, final Response response) {
-			LOGGER.error("No lower layer set for receiving response [{}]", response);
+			LOGGER.info("No lower layer set for receiving response [{}]", response);
 		}
 
 		@Override

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/Block2BlockwiseStatus.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/Block2BlockwiseStatus.java
@@ -149,7 +149,7 @@ public final class Block2BlockwiseStatus extends BlockwiseStatus {
 				return block2.getSzx();
 			}
 		}
-		LOGGER.debug("using default preferred block size for response: {}", preferredBlockSize);
+		LOGGER.trace("using default preferred block size for response: {}", preferredBlockSize);
 		return BlockOption.size2Szx(preferredBlockSize);
 	}
 

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/CountingCoapHandler.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/CountingCoapHandler.java
@@ -74,7 +74,7 @@ public class CountingCoapHandler implements CoapHandler {
 			}
 			notifyAll();
 		}
-		LOGGER.info("Received {}. Notification: {}", counter, response.advanced());
+		LOGGER.trace("Received {}. Notification: {}", counter, response.advanced());
 	}
 
 	/**

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/MemoryLeakingHashMapTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/MemoryLeakingHashMapTest.java
@@ -476,7 +476,7 @@ public class MemoryLeakingHashMapTest {
 				exchange.accept();
 			}
 
-			LOGGER.debug("TestResource [{}] received POST message: {}", new Object[]{getName(), exchange.getRequestText()});
+			LOGGER.trace("TestResource [{}] received POST message: {}", new Object[]{getName(), exchange.getRequestText()});
 
 			exchange.respond(ResponseCode.CREATED, currentResponseText);
 		}

--- a/californium-osgi/src/main/java/org/eclipse/californium/osgi/ManagedServer.java
+++ b/californium-osgi/src/main/java/org/eclipse/californium/osgi/ManagedServer.java
@@ -216,7 +216,7 @@ public class ManagedServer implements ManagedService, ServiceTrackerCustomizer<R
 	@Override
 	public Resource addingService(ServiceReference<Resource> reference) {
 		Resource resource = context.getService(reference);
-		LOGGER.debug("Adding resource [{}]", resource.getName());
+		LOGGER.trace("Adding resource [{}]", resource.getName());
 		if (resource != null) {
 			managedServer.add(resource);
 		}
@@ -235,7 +235,7 @@ public class ManagedServer implements ManagedService, ServiceTrackerCustomizer<R
 	@Override
 	public void removedService(ServiceReference<Resource> reference,
 			Resource service) {
-		LOGGER.debug("Removing resource [{}]", service.getName());
+		LOGGER.trace("Removing resource [{}]", service.getName());
 		managedServer.remove(service);
 		context.ungetService(reference);
 	}

--- a/californium-proxy/src/main/java/org/eclipse/californium/proxy/CoapTranslator.java
+++ b/californium-proxy/src/main/java/org/eclipse/californium/proxy/CoapTranslator.java
@@ -128,7 +128,7 @@ public final class CoapTranslator {
 			outgoingRequest.setURI(serverUri);
 		}
 
-		LOGGER.debug("Incoming request translated correctly");
+		LOGGER.trace("Incoming request translated correctly");
 		return outgoingRequest;
 	}
 	
@@ -166,7 +166,7 @@ public final class CoapTranslator {
 		outgoingResponse.setOptions(new OptionSet(
 				incomingResponse.getOptions()));
 		
-		LOGGER.debug("Incoming response translated correctly");
+		LOGGER.trace("Incoming response translated correctly");
 		return outgoingResponse;
 	}
 

--- a/californium-proxy/src/main/java/org/eclipse/californium/proxy/DirectProxyCoapResolver.java
+++ b/californium-proxy/src/main/java/org/eclipse/californium/proxy/DirectProxyCoapResolver.java
@@ -47,7 +47,7 @@ public class DirectProxyCoapResolver implements ProxyCoapResolver {
 
 	@Override
 	public void forwardRequest(Exchange exchange) {
-		LOGGER.debug("Forward CoAP request to ProxyCoap2Coap: {}", exchange.getRequest());
+		LOGGER.trace("Forward CoAP request to ProxyCoap2Coap: {}", exchange.getRequest());
 		proxyCoapClientResource.handleRequest(exchange);
 	}
 }

--- a/californium-proxy/src/main/java/org/eclipse/californium/proxy/HttpRequestContext.java
+++ b/californium-proxy/src/main/java/org/eclipse/californium/proxy/HttpRequestContext.java
@@ -64,7 +64,7 @@ public final class HttpRequestContext {
 			// translate the coap response in an http response
 			new HttpTranslator().getHttpResponse(httpRequest, coapResponse, httpResponse);
 
-			LOGGER.debug("Outgoing http response: {}", httpResponse.getStatusLine());
+			LOGGER.trace("Outgoing http response: {}", httpResponse.getStatusLine());
 		} catch (TranslationException e) {
 			LOGGER.warn("Failed to translate coap response to http response: {}", e.getMessage());
 			sendSimpleHttpResponse(HttpTranslator.STATUS_TRANSLATION_ERROR);

--- a/californium-proxy/src/main/java/org/eclipse/californium/proxy/HttpStack.java
+++ b/californium-proxy/src/main/java/org/eclipse/californium/proxy/HttpStack.java
@@ -191,7 +191,7 @@ public class HttpStack {
 				// Create server-side I/O reactor
 				ioReactor = new DefaultListeningIOReactor();
 				// Listen of the given port
-				LOGGER.info("HttpStack listening on port {}", httpPort);
+				LOGGER.trace("HttpStack listening on port {}", httpPort);
 				ioReactor.listen(new InetSocketAddress(httpPort));
 
 				// create the listener thread
@@ -240,7 +240,7 @@ public class HttpStack {
 				httpResponse.setEntity(new StringEntity("Californium Proxy server"));
 
 //				if (Bench_Help.DO_LOG) 
-					LOGGER.debug("Root request handled");
+					LOGGER.trace("Root request handled");
 			}
 		}
 
@@ -288,7 +288,7 @@ public class HttpStack {
 					// translate the request in a valid coap request
 					Request coapRequest = new HttpTranslator().getCoapRequest(httpRequest, localResource, proxyingEnabled);
 //					if (Bench_Help.DO_LOG) 
-						LOGGER.info("Received HTTP request and translate to {}", coapRequest);
+						LOGGER.debug("Received HTTP request and translate to {}", coapRequest);
 
 					// handle the requset
 					requestHandler.handleRequest(coapRequest, httpRequestContext);

--- a/californium-proxy/src/main/java/org/eclipse/californium/proxy/ProxyHttpServer.java
+++ b/californium-proxy/src/main/java/org/eclipse/californium/proxy/ProxyHttpServer.java
@@ -85,7 +85,7 @@ public class ProxyHttpServer {
 
 	public void handleRequest(final Request request, final HttpRequestContext context) {
 		
-		LOGGER.info("ProxyEndpoint handles request {}", request);
+		LOGGER.debug("ProxyEndpoint handles request {}", request);
 		
 		Exchange exchange = new Exchange(request, Origin.REMOTE, null) {
 
@@ -119,7 +119,7 @@ public class ProxyHttpServer {
 			// get the response from the cache
 			response = cacheResource.getResponse(request);
 
-				LOGGER.info("Cache returned {}", response);
+				LOGGER.debug("Cache returned {}", response);
 
 			// update statistics
 			statsResource.updateStatistics(request, response != null);
@@ -138,7 +138,7 @@ public class ProxyHttpServer {
 			if (request.getOptions().hasProxyUri()) {
 				try {
 					manageProxyUriRequest(request);
-					LOGGER.info("after manageProxyUriRequest: {}", request);
+					LOGGER.debug("after manageProxyUriRequest: {}", request);
 
 				} catch (URISyntaxException e) {
 					LOGGER.warn(String.format("Proxy-uri malformed: %s", request.getOptions().getProxyUri()));
@@ -184,7 +184,7 @@ public class ProxyHttpServer {
 			clientPath = PROXY_COAP_CLIENT;
 		}
 
-		LOGGER.info("Chose {} as clientPath", clientPath);
+		LOGGER.trace("Chose {} as clientPath", clientPath);
 
 		// set the path in the request to be forwarded correctly
 		request.getOptions().setUriPath(clientPath);

--- a/californium-proxy/src/main/java/org/eclipse/californium/proxy/resources/ProxyCoapClientResource.java
+++ b/californium-proxy/src/main/java/org/eclipse/californium/proxy/resources/ProxyCoapClientResource.java
@@ -81,7 +81,7 @@ public class ProxyCoapClientResource extends ForwardingResource {
 
 				@Override
 				public void onResponse(Response incomingResponse) {
-					LOGGER.debug("ProxyCoapClientResource received {}", incomingResponse);
+					LOGGER.trace("ProxyCoapClientResource received {}", incomingResponse);
 					exchange.sendResponse(CoapTranslator.getResponse(incomingResponse));
 					EndPointManagerPool.putClient(endpointManager);
 				}

--- a/cf-oscore/src/main/java/org/eclipse/californium/oscore/ObjectSecurityContextLayer.java
+++ b/cf-oscore/src/main/java/org/eclipse/californium/oscore/ObjectSecurityContextLayer.java
@@ -141,7 +141,7 @@ public class ObjectSecurityContextLayer extends AbstractLayer {
 
 					});
 					// send start rederivation request
-					LOGGER.info("Auxiliary Request: " + exchange.getRequest().toString());
+					LOGGER.trace("Auxiliary Request: " + exchange.getRequest().toString());
 					final Exchange newExchange = new Exchange(startRederivation, Origin.LOCAL, executor);
 					newExchange.execute(new Runnable() {
 
@@ -161,7 +161,7 @@ public class ObjectSecurityContextLayer extends AbstractLayer {
 				return;
 			}
 		}
-		LOGGER.info("Request: " + exchange.getRequest().toString());
+		LOGGER.trace("Request: " + exchange.getRequest().toString());
 		super.sendRequest(exchange, request);
 	}
 

--- a/cf-oscore/src/main/java/org/eclipse/californium/oscore/OptionJuggle.java
+++ b/cf-oscore/src/main/java/org/eclipse/californium/oscore/OptionJuggle.java
@@ -191,7 +191,7 @@ public class OptionJuggle {
 	 * @return a new optionSet which have had the non-special e options removed
 	 */
 	public static OptionSet discardEOptions(OptionSet optionSet) {
-		LOGGER.info("Removing inner only E options from the outer options");
+		LOGGER.trace("Removing inner only E options from the outer options");
 		OptionSet result = new OptionSet();
 		
 		for (Option opt : optionSet.asSortedList()) {

--- a/demo-apps/cf-extplugtest-client/src/main/java/org/eclipse/californium/extplugtests/BenchmarkClient.java
+++ b/demo-apps/cf-extplugtest-client/src/main/java/org/eclipse/californium/extplugtests/BenchmarkClient.java
@@ -1003,21 +1003,21 @@ public class BenchmarkClient {
 		if (tag != null) {
 			// with tag, use file
 			logger = LoggerFactory.getLogger(logger.getName() + ".file");
-			logger.info("------- {} ------------------------------------------------", tag);
-			logger.info("{}, {}, {}", osMxBean.getName(), osMxBean.getVersion(), osMxBean.getArch());
+			logger.trace("------- {} ------------------------------------------------", tag);
+			logger.trace("{}, {}, {}", osMxBean.getName(), osMxBean.getVersion(), osMxBean.getArch());
 			StringBuilder line = new StringBuilder();
 			List<String> vmArgs = ManagementFactory.getRuntimeMXBean().getInputArguments();
 			for (String arg : vmArgs) {
 				line.append(arg).append(" ");
 			}
-			logger.info("{}", line);
+			logger.trace("{}", line);
 			line.setLength(0);
 			for (String arg : args) {
 				line.append(arg).append(" ");
 			}
-			logger.info("{}", line);
+			logger.trace("{}", line);
 		}
-		logger.info("uptime: {} ms, {} processors", TimeUnit.NANOSECONDS.toMillis(uptimeNanos), processors);
+		logger.trace("uptime: {} ms, {} processors", TimeUnit.NANOSECONDS.toMillis(uptimeNanos), processors);
 		ThreadMXBean threadMxBean = ManagementFactory.getThreadMXBean();
 		if (threadMxBean.isThreadCpuTimeSupported() && threadMxBean.isThreadCpuTimeEnabled()) {
 			long alltime = 0;
@@ -1029,7 +1029,7 @@ public class BenchmarkClient {
 				}
 			}
 			long pTime = alltime / processors;
-			logger.info("cpu-time: {} ms (per-processor: {} ms, load: {}%)",
+			logger.trace("cpu-time: {} ms (per-processor: {} ms, load: {}%)",
 					TimeUnit.NANOSECONDS.toMillis(alltime), TimeUnit.NANOSECONDS.toMillis(pTime),
 					(pTime * 100) / uptimeNanos);
 		}
@@ -1045,7 +1045,7 @@ public class BenchmarkClient {
 				gcTime += time;
 			}
 		}
-		logger.info("gc: {} ms, {} calls", gcTime, gcCount);
+		logger.trace("gc: {} ms, {} calls", gcTime, gcCount);
 		double loadAverage = osMxBean.getSystemLoadAverage();
 		if (!(loadAverage < 0.0d)) {
 			logger.info("average load: {}", String.format("%.2f", loadAverage));

--- a/demo-apps/cf-extplugtest-client/src/main/java/org/eclipse/californium/extplugtests/resources/Feed.java
+++ b/demo-apps/cf-extplugtest-client/src/main/java/org/eclipse/californium/extplugtests/resources/Feed.java
@@ -226,7 +226,7 @@ public class Feed extends CoapResource {
 							response.getToken());
 				} else {
 					timeout = 0;
-					LOGGER.info("client[{}] next change in {} ms, {} observer.", id, interval, observer);
+					LOGGER.trace("client[{}] next change in {} ms, {} observer.", id, interval, observer);
 					executorService.schedule(change, interval, TimeUnit.MILLISECONDS);
 				}
 			} else {

--- a/demo-apps/cf-extplugtest-server/src/main/java/org/eclipse/californium/extplugtests/ExtendedTestServer.java
+++ b/demo-apps/cf-extplugtest-server/src/main/java/org/eclipse/californium/extplugtests/ExtendedTestServer.java
@@ -261,7 +261,7 @@ public class ExtendedTestServer extends AbstractTestServer {
 		OperatingSystemMXBean osMxBean = ManagementFactory.getOperatingSystemMXBean();
 		int processors = osMxBean.getAvailableProcessors();
 		Logger logger = STATISTIC_LOGGER;
-		logger.info("{} processors", processors);
+		logger.trace("{} processors", processors);
 		ThreadMXBean threadMxBean = ManagementFactory.getThreadMXBean();
 		if (threadMxBean.isThreadCpuTimeSupported() && threadMxBean.isThreadCpuTimeEnabled()) {
 			long alltime = 0;
@@ -273,7 +273,7 @@ public class ExtendedTestServer extends AbstractTestServer {
 				}
 			}
 			long pTime = alltime / processors;
-			logger.info("cpu-time: {} ms (per-processor: {} ms)",
+			logger.trace("cpu-time: {} ms (per-processor: {} ms)",
 					TimeUnit.NANOSECONDS.toMillis(alltime), TimeUnit.NANOSECONDS.toMillis(pTime));
 		}
 		long gcCount = 0;
@@ -288,7 +288,7 @@ public class ExtendedTestServer extends AbstractTestServer {
 				gcTime += time;
 			}
 		}
-		logger.info("gc: {} ms, {} calls", gcTime, gcCount);
+		logger.trace("gc: {} ms, {} calls", gcTime, gcCount);
 		double loadAverage = osMxBean.getSystemLoadAverage();
 		if (!(loadAverage < 0.0d)) {
 			logger.info("average load: {}", String.format("%.2f", loadAverage));

--- a/demo-apps/cf-extplugtest-server/src/main/java/org/eclipse/californium/extplugtests/resources/ReverseObserve.java
+++ b/demo-apps/cf-extplugtest-server/src/main/java/org/eclipse/californium/extplugtests/resources/ReverseObserve.java
@@ -429,7 +429,7 @@ public class ReverseObserve extends CoapResource implements NotificationListener
 		private void remove(ResponseCode code) {
 			String key = incomingExchange.getPeerKey();
 			observesByPeer.remove(key);
-			LOGGER.info("Removed observation for {}", key);
+			LOGGER.trace("Removed observation for {}", key);
 			incomingExchange.respond(code);
 		}
 	}

--- a/demo-apps/cf-extplugtest-server/src/main/java/org/eclipse/californium/extplugtests/resources/ReverseRequest.java
+++ b/demo-apps/cf-extplugtest-server/src/main/java/org/eclipse/californium/extplugtests/resources/ReverseRequest.java
@@ -185,8 +185,8 @@ public class ReverseRequest extends CoapResource {
 			if (overallSentRequests.getAndIncrement() == 0) {
 				LOGGER.info("start reverse requests!");
 			}
-			LOGGER.debug("{}", request);
-			LOGGER.info("{}/{}: {} reverse requests, {} overall.", request.getSourceContext().getPeerAddress(),
+			LOGGER.trace("{}", request);
+			LOGGER.trace("{}/{}: {} reverse requests, {} overall.", request.getSourceContext().getPeerAddress(),
 					resource, numberOfRequests, overall);
 			Endpoint endpoint = exchange.advanced().getEndpoint();
 			exchange.respond(CHANGED);

--- a/demo-apps/cf-helloworld-server/src/main/java/org/eclipse/californium/examples/MulticastTestServer.java
+++ b/demo-apps/cf-helloworld-server/src/main/java/org/eclipse/californium/examples/MulticastTestServer.java
@@ -55,14 +55,14 @@ public class MulticastTestServer {
 		if (NetworkInterfacesUtil.isAnyIpv6() && NetworkInterfacesUtil.isAnyIpv4()) {
 			connector = new UdpMulticastConnector(localAddress, CoAP.MULTICAST_IPV4, CoAP.MULTICAST_IPV6_LINKLOCAL,
 					CoAP.MULTICAST_IPV6_SITELOCAL);
-			LOGGER.info("IPv4 & IPv6");
+			LOGGER.debug("IPv4 & IPv6");
 		} else if (NetworkInterfacesUtil.isAnyIpv6()) {
 			connector = new UdpMulticastConnector(localAddress, CoAP.MULTICAST_IPV6_LINKLOCAL,
 					CoAP.MULTICAST_IPV6_SITELOCAL);
-			LOGGER.info("IPv6");
+			LOGGER.debug("IPv6");
 		} else {
 			connector = new UdpMulticastConnector(localAddress, CoAP.MULTICAST_IPV4);
-			LOGGER.info("IPv4");
+			LOGGER.debug("IPv4");
 		}
 		return new CoapEndpoint.Builder().setNetworkConfig(config).setConnector(connector).build();
 	}

--- a/demo-apps/cf-nat/src/main/java/org/eclipse/californium/examples/NatUtil.java
+++ b/demo-apps/cf-nat/src/main/java/org/eclipse/californium/examples/NatUtil.java
@@ -556,7 +556,7 @@ public class NatUtil implements Runnable {
 		} else {
 			forward = new MessageDropping("request", percent);
 			backward = new MessageDropping("responses", percent);
-			LOGGER.info("NAT message dropping {}%.", percent);
+			LOGGER.trace("NAT message dropping {}%.", percent);
 		}
 	}
 
@@ -577,7 +577,7 @@ public class NatUtil implements Runnable {
 			}
 		} else {
 			forward = new MessageDropping("request", percent);
-			LOGGER.info("NAT forward message dropping {}%.", percent);
+			LOGGER.trace("NAT forward message dropping {}%.", percent);
 		}
 	}
 
@@ -598,7 +598,7 @@ public class NatUtil implements Runnable {
 			}
 		} else {
 			backward = new MessageDropping("response", percent);
-			LOGGER.info("NAT backward message dropping {}%.", percent);
+			LOGGER.trace("NAT backward message dropping {}%.", percent);
 		}
 	}
 
@@ -624,7 +624,7 @@ public class NatUtil implements Runnable {
 			}
 		} else {
 			reorder = new MessageReordering("reordering", percent, delayMillis, randomDelayMillis);
-			LOGGER.info("NAT message reordering {}%.", percent);
+			LOGGER.trace("NAT message reordering {}%.", percent);
 		}
 	}
 

--- a/element-connector-tcp-netty/src/main/java/org/eclipse/californium/elements/tcp/netty/TcpClientConnector.java
+++ b/element-connector-tcp-netty/src/main/java/org/eclipse/californium/elements/tcp/netty/TcpClientConnector.java
@@ -326,7 +326,7 @@ public class TcpClientConnector implements Connector {
 
 		@Override
 		public void channelCreated(Channel ch) throws Exception {
-			LOGGER.debug("new channel to {}", key);
+			LOGGER.trace("new channel to {}", key);
 			onNewChannelCreated(key, ch);
 
 			// Handler order:

--- a/element-connector-tcp-netty/src/main/java/org/eclipse/californium/elements/tcp/netty/TcpContextUtil.java
+++ b/element-connector-tcp-netty/src/main/java/org/eclipse/californium/elements/tcp/netty/TcpContextUtil.java
@@ -42,7 +42,7 @@ public class TcpContextUtil {
 		InetSocketAddress address = (InetSocketAddress) channel.remoteAddress();
 		String id = channel.id().asShortText();
 		EndpointContext context = new TcpEndpointContext(address, id);
-		LOGGER.debug("{}", context);
+		LOGGER.trace("{}", context);
 		return context;
 	}
 }

--- a/element-connector-tcp-netty/src/main/java/org/eclipse/californium/elements/tcp/netty/TlsClientConnector.java
+++ b/element-connector-tcp-netty/src/main/java/org/eclipse/californium/elements/tcp/netty/TlsClientConnector.java
@@ -152,7 +152,7 @@ public class TlsClientConnector extends TcpClientConnector {
 	private SSLEngine createSllEngine(SocketAddress remoteAddress) {
 		if (remoteAddress instanceof InetSocketAddress) {
 			InetSocketAddress remote = (InetSocketAddress) remoteAddress;
-			LOGGER.info("Connection to inet {}", remote);
+			LOGGER.trace("Connection to inet {}", remote);
 			return sslContext.createSSLEngine(remote.getAddress().getHostAddress(), remote.getPort());
 		} else {
 			LOGGER.info("Connection to {}", remoteAddress);

--- a/element-connector-tcp-netty/src/main/java/org/eclipse/californium/elements/tcp/netty/TlsContextUtil.java
+++ b/element-connector-tcp-netty/src/main/java/org/eclipse/californium/elements/tcp/netty/TlsContextUtil.java
@@ -93,7 +93,7 @@ public class TlsContextUtil extends TcpContextUtil {
 				// getPeerCertificates fails
 				checkKerberos = true;
 			} catch (RuntimeException e) {
-				LOGGER.warn("TLS({}) failed to extract principal {}", id, e.getMessage());
+				LOGGER.trace("TLS({}) failed to extract principal {}", id, e.getMessage());
 			}
 
 			if (checkKerberos) {
@@ -102,7 +102,7 @@ public class TlsContextUtil extends TcpContextUtil {
 				} catch (SSLPeerUnverifiedException e2) {
 					// still unverified, so also no kerberos
 					if (warnMissingPrincipal) {
-						LOGGER.warn("TLS({}) failed to verify principal, {}", id, e2.getMessage());
+						LOGGER.trace("TLS({}) failed to verify principal, {}", id, e2.getMessage());
 					} else {
 						LOGGER.trace("TLS({}) failed to verify principal, {}", id, e2.getMessage());
 					}
@@ -110,9 +110,9 @@ public class TlsContextUtil extends TcpContextUtil {
 			}
 
 			if (principal != null) {
-				LOGGER.debug("TLS({}) Principal {}", id, principal.getName());
+				LOGGER.trace("TLS({}) Principal {}", id, principal.getName());
 			} else if (warnMissingPrincipal) {
-				LOGGER.warn("TLS({}) principal missing", id);
+				LOGGER.trace("TLS({}) principal missing", id);
 			} else {
 				LOGGER.trace("TLS({}) principal missing", id);
 			}
@@ -121,7 +121,7 @@ public class TlsContextUtil extends TcpContextUtil {
 			if (sessionId != null && sessionId.length > 0) {
 				String sslId = StringUtil.byteArray2HexString(sessionId, StringUtil.NO_SEPARATOR, 0);
 				String cipherSuite = sslSession.getCipherSuite();
-				LOGGER.debug("TLS({},{},{})", id, StringUtil.trunc(sslId, 14), cipherSuite);
+				LOGGER.trace("TLS({},{},{})", id, StringUtil.trunc(sslId, 14), cipherSuite);
 				return new TlsEndpointContext(address, principal, id, sslId, cipherSuite);
 			}
 		}

--- a/element-connector-tcp-netty/src/main/java/org/eclipse/californium/elements/tcp/netty/TlsServerConnector.java
+++ b/element-connector-tcp-netty/src/main/java/org/eclipse/californium/elements/tcp/netty/TlsServerConnector.java
@@ -138,7 +138,7 @@ public class TlsServerConnector extends TcpServerConnector {
 		SocketAddress remoteAddress = ch.remoteAddress();
 		if (remoteAddress instanceof InetSocketAddress) {
 			InetSocketAddress remote = (InetSocketAddress) remoteAddress;
-			LOGGER.info("Connection from inet {}", remote);
+			LOGGER.trace("Connection from inet {}", remote);
 			return sslContext.createSSLEngine(remote.getAddress().getHostAddress(), remote.getPort());
 		} else {
 			LOGGER.info("Connection from {}", remoteAddress);

--- a/element-connector/src/test/java/org/eclipse/californium/elements/UDPConnectorTest.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/UDPConnectorTest.java
@@ -197,7 +197,7 @@ public class UDPConnectorTest {
 		EndpointContext context = new UdpEndpointContext(dest);
 
 		for (int loop = 0; loop < loops; ++loop) {
-			LOGGER.info("start/stop: {}/{} loops, {} msgs", loop, loops, pending);
+			LOGGER.severe("start/stop: {}/{} loops, {} msgs", loop, loops, pending);
 			TestEndpointContextMatcher matcher = new TestEndpointContextMatcher(pending, pending);
 			connector.setEndpointContextMatcher(matcher);
 

--- a/element-connector/src/test/java/org/eclipse/californium/elements/rule/NetworkRule.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/rule/NetworkRule.java
@@ -275,7 +275,7 @@ public class NetworkRule implements TestRule {
 			RULES_STACK.push(this);
 			size = RULES_STACK.size();
 		}
-		LOGGER.info("{} rules active.", size);
+		LOGGER.debug("{} rules active.", size);
 		initNetwork(first);
 	}
 
@@ -297,7 +297,7 @@ public class NetworkRule implements TestRule {
 			activeRule = RULES_STACK.peek();
 			size = RULES_STACK.size();
 		}
-		LOGGER.info("{} rules active.", size);
+		LOGGER.debug("{} rules active.", size);
 		if (this != closedRule) {
 			throw new IllegalStateException("closed rule differs!");
 		}
@@ -422,7 +422,7 @@ public class NetworkRule implements TestRule {
 			size = RULES_STACK.size();
 			active = !RULES_STACK.isEmpty();
 		}
-		LOGGER.info("{} rules active.", size);
+		LOGGER.debug("{} rules active.", size);
 		return active;
 	}
 }

--- a/element-connector/src/test/java/org/eclipse/californium/elements/rule/TestNameLoggerRule.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/rule/TestNameLoggerRule.java
@@ -29,6 +29,6 @@ public class TestNameLoggerRule extends TestWatcher {
 
 	@Override
 	protected void starting(Description description) {
-		LOGGER.info("Test {}", description.getMethodName());
+		LOGGER.debug("Test {}", description.getMethodName());
 	}
 }

--- a/element-connector/src/test/java/org/eclipse/californium/elements/rule/ThreadsRule.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/rule/ThreadsRule.java
@@ -184,7 +184,7 @@ public class ThreadsRule implements TestRule {
 	 * @param list list of threads
 	 */
 	public void dump(String message, List<Thread> list) {
-		LOGGER.info("Threads {}: {} threads", message, list.size());
+		LOGGER.debug("Threads {}: {} threads", message, list.size());
 		for (Thread thread : list) {
 			ThreadGroup threadGroup = thread.getThreadGroup();
 			if (threadGroup != null) {

--- a/element-connector/src/test/java/org/eclipse/californium/elements/util/DirectDatagramSocketImpl.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/util/DirectDatagramSocketImpl.java
@@ -628,7 +628,7 @@ public class DirectDatagramSocketImpl extends AbstractDatagramSocketImpl {
 		String message;
 		while ((message = logBuffer.poll()) != null) {
 			++counter;
-			LOGGER.info(String.format("--%02d--> %s", counter, message));
+			LOGGER.debug(String.format("--%02d--> %s", counter, message));
 		}
 	}
 

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/DTLSConnector.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/DTLSConnector.java
@@ -1076,7 +1076,7 @@ public class DTLSConnector implements Connector, RecordLayer {
 
 		byte[] data = Arrays.copyOfRange(packet.getData(), packet.getOffset(), packet.getLength());
 		List<Record> records = Record.fromByteArray(data, peerAddress, connectionIdGenerator, timestamp);
-		LOGGER.debug("Received {} DTLS records from {} using a {} byte datagram buffer",
+		LOGGER.trace("Received {} DTLS records from {} using a {} byte datagram buffer",
 				records.size(), peerAddress, inboundDatagramBufferSize);
 
 		if (records.isEmpty()) {

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/DtlsHealthLogger.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/DtlsHealthLogger.java
@@ -67,7 +67,7 @@ public class DtlsHealthLogger implements DtlsHealth {
 				log.append(head).append(droppedSentRecords).append(eol);
 				log.append(head).append(receivedRecords).append(eol);
 				log.append(head).append(droppedReceivedRecords);
-				LOGGER.debug("{}", log);
+				LOGGER.trace("{}", log);
 			}
 		} catch (Throwable e) {
 			LOGGER.error("{}", tag, e);

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/CertificateRequest.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/CertificateRequest.java
@@ -525,7 +525,7 @@ public final class CertificateRequest extends HandshakeMessage {
 				return true;
 			}
 		}
-		LOGGER.debug("certificate is NOT signed with supported algorithm(s)");
+		LOGGER.trace("certificate is NOT signed with supported algorithm(s)");
 		return false;
 	}
 

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ClientHandshaker.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ClientHandshaker.java
@@ -668,7 +668,7 @@ public class ClientHandshaker extends Handshaker {
 		if (maxFragmentLengthCode != null) {
 			MaxFragmentLengthExtension ext = new MaxFragmentLengthExtension(maxFragmentLengthCode); 
 			helloMessage.addExtension(ext);
-			LOGGER.debug(
+			LOGGER.trace(
 					"Indicating max. fragment length [{}] to server [{}]",
 					maxFragmentLengthCode, getPeerAddress());
 		}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/DebugConnectionStore.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/DebugConnectionStore.java
@@ -147,7 +147,7 @@ public final class DebugConnectionStore extends InMemoryConnectionStore {
 	private <K> void dump(ConcurrentMap<K, Connection> map) {
 		for (K key : map.keySet()) {
 			Connection connection = map.get(key);
-			LOG.warn("  {} connection: {} - {}", tag, key, connection);
+			LOG.debug("  {} connection: {} - {}", tag, key, connection);
 		}
 	}
 }

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/InMemoryConnectionStore.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/InMemoryConnectionStore.java
@@ -470,7 +470,7 @@ public class InMemoryConnectionStore implements ResumptionSupportingConnectionSt
 	@Override
 	public synchronized int remainingCapacity() {
 		int remaining = connections.remainingCapacity();
-		LOG.debug("{}connection: size {}, remaining {}!", tag, connections.size(), remaining);
+		LOG.trace("{}connection: size {}, remaining {}!", tag, connections.size(), remaining);
 		return remaining;
 	}
 

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/ReassemblingHandshakeMessageTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/ReassemblingHandshakeMessageTest.java
@@ -96,7 +96,7 @@ public class ReassemblingHandshakeMessageTest {
 	}
 
 	private void log(FragmentedHandshakeMessage msg) {
-		LOGGER.info(" fragment [{}:{})", msg.getFragmentOffset(), msg.getFragmentOffset() + msg.getFragmentLength());
+		LOGGER.trace(" fragment [{}:{})", msg.getFragmentOffset(), msg.getFragmentOffset() + msg.getFragmentLength());
 	}
 
 	private void log() {
@@ -107,9 +107,9 @@ public class ReassemblingHandshakeMessageTest {
 
 	private void log(ReassemblingHandshakeMessage reassembledMessage) {
 		List<Object> ranges = reassembledMessage.getRanges();
-		LOGGER.info("{} ranges", ranges.size());
+		LOGGER.trace("{} ranges", ranges.size());
 		for (Object range : ranges) {
-			LOGGER.info("  {}", range);
+			LOGGER.trace("  {}", range);
 		}
 	}
 


### PR DESCRIPTION
We appreciate your previous feedback and it's very helpful! Here's a reissue of https://github.com/eclipse/californium/pull/933 with a new version of our tool.  Again, we'd appreciate any feedback and are willing to make further changes if you wish to incorporate our PR into your project.

Settings
---
We have several analysis settings. We can vary these settings and rerun if you desire. The settings we are using in this pull request are:

- Never lower the logging level of logging statements within catch blocks.
- Never lower the logging level of logging statements within if statements.
- Never lower the logging level of logging statements containing certain (important) keywords.
- Never raise the logging level of logging statements without particular keywords in their messages.
- Avoid log wrapping by disregarding logging statements contained in if statements mentioning log levels.
- Consistent log level transformations between overriding methods.
- Maximum allowed transformation distance: 2.

The greatest number of commits from HEAD evaluated: 1000.
The head at the time of analysis was: 785267fc8a2486260e1e65144ebaf6ca1c1ac81b


- [x] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/selenium/blob/master/CONTRIBUTING.md#step-6-sign-the-cla)

